### PR TITLE
blog: Your assistant remembers (ovos-memory-plugins)

### DIFF
--- a/_posts/2026-08-05-your-assistant-remembers.md
+++ b/_posts/2026-08-05-your-assistant-remembers.md
@@ -1,0 +1,118 @@
+---
+title: "Your Assistant Remembers: Long-Term and Local-First Memory for OVOS Personas"
+excerpt: "ovos-memory-plugins gives OVOS personas a memory: rolling LLM summarization for the gist of long chats, fully on-device RAG for exact recall, plus lightweight keyword, recency, entity, and ensemble backends — all behind one config key, all able to run without touching the cloud."
+coverImage: "/assets/blog/ngi/thumb.png"
+date: "2026-08-05T00:00:00.000Z"
+author:
+  name: JarbasAl
+  picture: "https://avatars.githubusercontent.com/u/33701864"
+ogImage:
+  url: "/assets/blog/ngi/thumb.png"
+---
+
+## Your Assistant Remembers
+
+A voice assistant is stateless by default. Ask about the weather, get an answer, move on — and the next time you speak, nothing you said before is remembered. For one-off commands that is fine. For a persona you talk to every day, it is a real limitation: no continuity, no sense of who you are, no ability to follow up on yesterday's conversation.
+
+[`ovos-memory-plugins`](https://github.com/OpenVoiceOS/ovos-memory-plugins) closes that gap. It is a bundle of memory backends that plug into [`ovos-persona`](https://github.com/OpenVoiceOS/ovos-persona) through a single, well-defined seam. Each backend is an `AgentContextManager` from `ovos-plugin-manager`, registered under the `opm.agents.memory` entry-point group, and a persona activates exactly one of them with a single line of JSON.
+
+## The seam: one small contract
+
+A memory plugin does not answer questions. The persona still owns the chat engine and any tools; the memory plugin owns **conversation state and context assembly**. The whole contract is three methods (`ovos_plugin_manager.templates.agents`):
+
+```python
+get_history(session_id) -> List[AgentMessage]
+update_history(new_messages, session_id) -> None
+build_conversation_context(utterance, session_id) -> List[AgentMessage]
+```
+
+Before every turn the persona calls `build_conversation_context`, sends the returned message list to the chat engine, then calls `update_history` with the new exchange. Two invariants hold for every backend: the first message may be a `system` message carrying the persona's base prompt, and the last message is always the current user utterance. Because the interface is this narrow, memory backends are interchangeable — you swap recall strategies without touching the persona.
+
+## Long-term summarization
+
+`ovos-memory-plugin-longterm` keeps a compact running summary of a long conversation. Every `summarize_every` exchanges (default 6), it sends the oldest turns to an OpenAI-compatible **chat** endpoint, replaces those turns with the returned summary, and keeps only the last `recent_window` exchanges verbatim. On the next turn the context is: the system prompt plus the rolling summary, then the recent verbatim turns, then the utterance.
+
+```
+Session store (JSON or SQLite)
+  rolling_summary  <- LLM summarizes every N exchanges
+  recent_window    <- last few exchanges, verbatim
+```
+
+This trades exact recall for a bounded, cheap-to-carry context — the gist of a long chat instead of every word. The endpoint is just a URL, so point it at a local `llama.cpp`/Ollama server and the summarization never leaves your machine:
+
+```json
+{
+  "memory_module": "ovos-memory-plugin-longterm",
+  "ovos-memory-plugin-longterm": {
+    "api_url": "http://localhost:8000/v1",
+    "model": "mistral",
+    "summarize_every": 8,
+    "recent_window": 4,
+    "backend": "sqlite",
+    "db_path": "~/.local/share/ovos/assistant_memory.db"
+  }
+}
+```
+
+## Local-first RAG
+
+When you need the assistant to recall a *specific* fact rather than a gist, use `ovos-memory-plugin-local-rag`. It stores every exchange as an embedding in a vector store and, at query time, retrieves the top-k most semantically similar past turns and injects them as context — so relevant history surfaces without the entire transcript overflowing the context window.
+
+The "local" is the whole point. Retrieval runs **entirely in-process**: the plugin loads an OVOS text-embeddings plugin and an `EmbeddingsDB` plugin directly — no HTTP, no API key. The `local-rag` extra pulls a default offline stack of `ovos-gguf-embeddings-plugin` (a LaBSE GGUF embedding model) and `ovos-chromadb-embeddings-plugin` (a persistent on-disk vector store). Nothing about your conversation history is embedded or searched anywhere but the device it lives on. This is a deliberate design decision: an earlier server-coupled HTTP variant was removed outright (PR #9) in favor of the local-first one.
+
+```json
+{
+  "memory_module": "ovos-memory-plugin-local-rag",
+  "ovos-memory-plugin-local-rag": {
+    "embeddings_plugin": "ovos-gguf-embeddings-plugin",
+    "embeddings_db_plugin": "ovos-chromadb-embeddings-plugin",
+    "embeddings_db_config": {"path": "~/.local/share/ovos/local_rag_db"},
+    "retrieval": {"max_num_results": 5, "min_score": null}
+  }
+}
+```
+
+Retrieved chunks can be woven into the conversation in several ways via `inject_mode`: a separate `system` message (the default, which keeps the base prompt stable and cacheable), folded into the system prompt, prepended to the user turn, or — for tool-calling models — presented as a synthetic `search_memory` tool result. The store, the embedding model, and the injection style are all swappable; point `embeddings_db_plugin` at `ovos-qdrant-embeddings-plugin` and the same retrieval logic runs against a shared Qdrant instead.
+
+## Lightweight backends, and an ensemble
+
+Summarization and RAG are the heavyweights, but the family has grown to cover cheaper strategies too:
+
+- **`ovos-memory-plugin-lexical`** — keyword recall using SQLite's built-in FTS5 index and `bm25()` ranking. No embeddings, no extra dependencies (`sqlite3` is stdlib), fully offline. Use it when the exact term matters more than the meaning.
+- **`ovos-memory-plugin-recency`** — the lightest option: a sliding window of the most recent turns, bounded by count and optionally by age. No LLM, no embeddings.
+- **`ovos-memory-plugin-entity`** — durable facts about the user (name, preferences, relationships, goals). After each exchange it asks a **local** OpenAI-compatible endpoint to extract short fact lines and merges them, deduplicated, into a per-session store, then re-injects them every turn. If the endpoint is unreachable, extraction simply no-ops.
+- **`ovos-memory-plugin-composite`** — a pure orchestrator that stores nothing itself. It loads several of the above as members, fuses the retriever hits (RAG + lexical) into one deduplicated ranked list via reciprocal-rank fusion, folds in the summary/facts from the others, and writes every new exchange through to all of them. A member that fails to load or raises is simply skipped. This is how a persona's single `memory_module` slot combines hybrid recall — semantic *and* keyword *and* durable facts at once.
+
+The overview table in the repo lays out the trade-offs: which backends run fully offline, which need a chat endpoint, and how each persists state.
+
+## Per-session by design
+
+Every backend keys its state by `session_id`, so memory is naturally per-session. In a shared household each person's conversation stays separate, and a guest session simply carries its own (or an empty) window. The persona resolves the backend and its per-plugin config block by name at load time — the same mechanism used for solver configs — so enabling memory really is one key:
+
+```json
+{
+  "name": "MyAssistant",
+  "solvers": ["ovos-solver-openai-plugin"],
+  "memory_module": "ovos-memory-plugin-local-rag"
+}
+```
+
+Nothing else changes about the persona. It just starts remembering — and, if you choose the local-first backends, it remembers without anything leaving the device.
+
+---
+
+This work is part of the OpenVoiceOS **From Beta to Breakthrough** milestone, funded through the [NGI0 Commons Fund](https://nlnet.nl/commonsfund), a fund established by [NLnet](https://nlnet.nl) with financial support from the European Commission's [Next Generation Internet](https://ngi.eu) programme, under the aegis of [DG Communications Networks, Content and Technology](https://commission.europa.eu/about-european-commission/departments-and-executive-agencies/communications-networks-content-and-technology_en) under grant agreement No [101135429](https://cordis.europa.eu/project/id/101135429). Additional funding is made available by the [Swiss State Secretariat for Education, Research and Innovation](https://www.sbfi.admin.ch/sbfi/en/home.html) (SERI).
+
+---
+
+## Help Us Build Voice for Everyone
+
+OpenVoiceOS is more than software, it's a mission. If you believe voice assistants should be open, inclusive, and user-controlled, here's how you can help:
+
+- **💸 Donate**: Help us fund development, infrastructure, and legal protection.
+- **📣 Contribute Open Data**: Share voice samples and transcriptions under open licenses.
+- **🌍 Translate**: Help make OVOS accessible in every language.
+
+We're not building this for profit. We're building it for people. With your support, we can keep voice tech transparent, private, and community-owned.
+
+👉 [Support the project here](https://www.openvoiceos.org/contribution)

--- a/_posts/2026-08-05-your-assistant-remembers.md
+++ b/_posts/2026-08-05-your-assistant-remembers.md
@@ -12,13 +12,13 @@ ogImage:
 
 ## Your Assistant Remembers
 
-A voice assistant is stateless by default. Ask about the weather, get an answer, move on — and the next time you speak, nothing you said before is remembered. For one-off commands that is fine. For a persona you talk to every day, it is a real limitation: no continuity, no sense of who you are, no ability to follow up on yesterday's conversation.
+A voice assistant is stateless by default. Ask about the weather, get an answer, move on — next time you speak, nothing you said before is remembered. Fine for one-off commands. For a persona you talk to every day, it means no continuity, no sense of who you are, no way to follow up on yesterday's conversation.
 
-[`ovos-memory-plugins`](https://github.com/OpenVoiceOS/ovos-memory-plugins) closes that gap. It is a bundle of memory backends that plug into [`ovos-persona`](https://github.com/OpenVoiceOS/ovos-persona) through a single, well-defined seam. Each backend is an `AgentContextManager` from `ovos-plugin-manager`, registered under the `opm.agents.memory` entry-point group, and a persona activates exactly one of them with a single line of JSON.
+[`ovos-memory-plugins`](https://github.com/OpenVoiceOS/ovos-memory-plugins) closes that gap: a bundle of memory backends that plug into [`ovos-persona`](https://github.com/OpenVoiceOS/ovos-persona) through one well-defined seam. A persona activates exactly one backend with a single line of JSON.
 
 ## The seam: one small contract
 
-A memory plugin does not answer questions. The persona still owns the chat engine and any tools; the memory plugin owns **conversation state and context assembly**. The whole contract is three methods (`ovos_plugin_manager.templates.agents`):
+A memory plugin does not answer questions. The persona still owns the chat engine and any tools; the memory plugin owns **conversation state and context assembly**. Each backend is an `AgentContextManager` from `ovos-plugin-manager`, registered under the `opm.agents.memory` entry-point group, and the whole contract is three methods (`ovos_plugin_manager.templates.agents`):
 
 ```python
 get_history(session_id) -> List[AgentMessage]
@@ -26,11 +26,11 @@ update_history(new_messages, session_id) -> None
 build_conversation_context(utterance, session_id) -> List[AgentMessage]
 ```
 
-Before every turn the persona calls `build_conversation_context`, sends the returned message list to the chat engine, then calls `update_history` with the new exchange. Two invariants hold for every backend: the first message may be a `system` message carrying the persona's base prompt, and the last message is always the current user utterance. Because the interface is this narrow, memory backends are interchangeable — you swap recall strategies without touching the persona.
+Before every turn, the persona calls `build_conversation_context`, sends the returned message list to the chat engine, then calls `update_history` with the new exchange. Two invariants hold for every backend: the first message may be a `system` message carrying the persona's base prompt, and the last message is always the current user utterance. Because the interface is this narrow, backends are interchangeable — swap recall strategies without touching the persona.
 
 ## Long-term summarization
 
-`ovos-memory-plugin-longterm` keeps a compact running summary of a long conversation. Every `summarize_every` exchanges (default 6), it sends the oldest turns to an OpenAI-compatible **chat** endpoint, replaces those turns with the returned summary, and keeps only the last `recent_window` exchanges verbatim. On the next turn the context is: the system prompt plus the rolling summary, then the recent verbatim turns, then the utterance.
+`ovos-memory-plugin-longterm` keeps a compact running summary of a long conversation. Every `summarize_every` exchanges (default 6), it sends the oldest turns to an OpenAI-compatible **chat** endpoint, replaces those turns with the returned summary, and keeps only the last `recent_window` exchanges verbatim. The next turn's context is: system prompt, then rolling summary, then the recent verbatim turns, then the utterance.
 
 ```
 Session store (JSON or SQLite)
@@ -38,7 +38,7 @@ Session store (JSON or SQLite)
   recent_window    <- last few exchanges, verbatim
 ```
 
-This trades exact recall for a bounded, cheap-to-carry context — the gist of a long chat instead of every word. The endpoint is just a URL, so point it at a local `llama.cpp`/Ollama server and the summarization never leaves your machine:
+This trades exact recall for a bounded, cheap-to-carry context — the gist of a long chat instead of every word. The endpoint is just a URL, so point it at a local `llama.cpp` or Ollama server and the summarization never leaves your machine:
 
 ```json
 {
@@ -56,9 +56,9 @@ This trades exact recall for a bounded, cheap-to-carry context — the gist of a
 
 ## Local-first RAG
 
-When you need the assistant to recall a *specific* fact rather than a gist, use `ovos-memory-plugin-local-rag`. It stores every exchange as an embedding in a vector store and, at query time, retrieves the top-k most semantically similar past turns and injects them as context — so relevant history surfaces without the entire transcript overflowing the context window.
+When the assistant needs to recall a specific fact rather than a gist, use `ovos-memory-plugin-local-rag`. It stores every exchange as an embedding in a vector store and, at query time, retrieves the top-k most semantically similar past turns and injects them as context — so relevant history surfaces without the entire transcript overflowing the context window.
 
-The "local" is the whole point. Retrieval runs **entirely in-process**: the plugin loads an OVOS text-embeddings plugin and an `EmbeddingsDB` plugin directly — no HTTP, no API key. The `local-rag` extra pulls a default offline stack of `ovos-gguf-embeddings-plugin` (a LaBSE GGUF embedding model) and `ovos-chromadb-embeddings-plugin` (a persistent on-disk vector store). Nothing about your conversation history is embedded or searched anywhere but the device it lives on. This is a deliberate design decision: an earlier server-coupled HTTP variant was removed outright (PR #9) in favor of the local-first one.
+"Local" is the point: retrieval runs entirely in-process. The plugin loads an OVOS text-embeddings plugin and an `EmbeddingsDB` plugin directly — no HTTP, no API key. The `local-rag` extra pulls a default offline stack of `ovos-gguf-embeddings-plugin` (a LaBSE GGUF embedding model) and `ovos-chromadb-embeddings-plugin` (a persistent on-disk vector store), so nothing about your conversation history is embedded or searched anywhere but the device it lives on. An earlier server-coupled HTTP variant was removed outright (PR #9) in favor of this local-first design.
 
 ```json
 {
@@ -72,22 +72,22 @@ The "local" is the whole point. Retrieval runs **entirely in-process**: the plug
 }
 ```
 
-Retrieved chunks can be woven into the conversation in several ways via `inject_mode`: a separate `system` message (the default, which keeps the base prompt stable and cacheable), folded into the system prompt, prepended to the user turn, or — for tool-calling models — presented as a synthetic `search_memory` tool result. The store, the embedding model, and the injection style are all swappable; point `embeddings_db_plugin` at `ovos-qdrant-embeddings-plugin` and the same retrieval logic runs against a shared Qdrant instead.
+Retrieved chunks can be woven into the conversation via `inject_mode`: a separate `system` message (the default, which keeps the base prompt stable and cacheable), folded into the system prompt, prepended to the user turn, or — for tool-calling models — presented as a synthetic `search_memory` tool result. The store, the embedding model, and the injection style are all swappable; point `embeddings_db_plugin` at `ovos-qdrant-embeddings-plugin` and the same retrieval logic runs against a shared Qdrant instead.
 
-## Lightweight backends, and an ensemble
+## Lighter backends, and an ensemble
 
-Summarization and RAG are the heavyweights, but the family has grown to cover cheaper strategies too:
+Summarization and RAG are the heavyweights. The family also covers cheaper strategies:
 
 - **`ovos-memory-plugin-lexical`** — keyword recall using SQLite's built-in FTS5 index and `bm25()` ranking. No embeddings, no extra dependencies (`sqlite3` is stdlib), fully offline. Use it when the exact term matters more than the meaning.
 - **`ovos-memory-plugin-recency`** — the lightest option: a sliding window of the most recent turns, bounded by count and optionally by age. No LLM, no embeddings.
-- **`ovos-memory-plugin-entity`** — durable facts about the user (name, preferences, relationships, goals). After each exchange it asks a **local** OpenAI-compatible endpoint to extract short fact lines and merges them, deduplicated, into a per-session store, then re-injects them every turn. If the endpoint is unreachable, extraction simply no-ops.
-- **`ovos-memory-plugin-composite`** — a pure orchestrator that stores nothing itself. It loads several of the above as members, fuses the retriever hits (RAG + lexical) into one deduplicated ranked list via reciprocal-rank fusion, folds in the summary/facts from the others, and writes every new exchange through to all of them. A member that fails to load or raises is simply skipped. This is how a persona's single `memory_module` slot combines hybrid recall — semantic *and* keyword *and* durable facts at once.
+- **`ovos-memory-plugin-entity`** — durable facts about the user (name, preferences, relationships, goals). After each exchange it asks a local OpenAI-compatible endpoint to extract short fact lines and merges them, deduplicated, into a per-session store, then re-injects them every turn. If the endpoint is unreachable, extraction simply no-ops.
+- **`ovos-memory-plugin-composite`** — a pure orchestrator that stores nothing itself. It loads several of the above as members, fuses the retriever hits (RAG + lexical) into one deduplicated ranked list via reciprocal-rank fusion, folds in the summary and facts from the others, and writes every new exchange through to all of them. A member that fails to load or raises is simply skipped. This is how a persona's single `memory_module` slot combines hybrid recall — semantic, keyword, and durable facts at once.
 
 The overview table in the repo lays out the trade-offs: which backends run fully offline, which need a chat endpoint, and how each persists state.
 
-## Per-session by design
+## One config key
 
-Every backend keys its state by `session_id`, so memory is naturally per-session. In a shared household each person's conversation stays separate, and a guest session simply carries its own (or an empty) window. The persona resolves the backend and its per-plugin config block by name at load time — the same mechanism used for solver configs — so enabling memory really is one key:
+Every backend keys its state by `session_id`, so memory is naturally per-session. In a shared household each person's conversation stays separate, and a guest session carries its own — or an empty — window. The persona resolves the backend and its per-plugin config block by name at load time, the same mechanism used for solver configs. Enabling memory is one key:
 
 ```json
 {
@@ -97,7 +97,7 @@ Every backend keys its state by `session_id`, so memory is naturally per-session
 }
 ```
 
-Nothing else changes about the persona. It just starts remembering — and, if you choose the local-first backends, it remembers without anything leaving the device.
+Nothing else about the persona changes. It just starts remembering — and with a local-first backend, it remembers without anything leaving the device.
 
 ---
 

--- a/_posts/2026-08-05-your-assistant-remembers.md
+++ b/_posts/2026-08-05-your-assistant-remembers.md
@@ -14,9 +14,33 @@ ogImage:
 
 A voice assistant is stateless by default. Ask about the weather, get an answer, move on — next time you speak, nothing you said before is remembered. Fine for one-off commands. For a persona you talk to every day, it means no continuity, no sense of who you are, no way to follow up on yesterday's conversation.
 
-[`ovos-memory-plugins`](https://github.com/OpenVoiceOS/ovos-memory-plugins) closes that gap: a bundle of memory backends that plug into [`ovos-persona`](https://github.com/OpenVoiceOS/ovos-persona) through one well-defined seam. A persona activates exactly one backend with a single line of JSON.
+In plain terms: right now, if you tell your assistant your dog's name on Monday, it has no idea by Tuesday. With [`ovos-memory-plugins`](https://github.com/OpenVoiceOS/ovos-memory-plugins), that changes. Depending on which memory a persona is set up with, it can recall the gist of a long conversation, look up something you said days ago, or just remember the last few things you said so "and what about tomorrow?" makes sense. Everything runs on the device — nothing about your conversations is sent to a cloud service.
 
-## The seam: one small contract
+Setting this up today means editing a persona's configuration file, so this post is aimed at people who build or configure OVOS personas, not at end users tapping a settings screen. If you just run OVOS and talk to it, the takeaway is: memory is coming to personas, and it stays local. The rest of this post is for the people wiring that up.
+
+## For persona builders: how it works
+
+[`ovos-memory-plugins`](https://github.com/OpenVoiceOS/ovos-memory-plugins) is a bundle of memory backends that plug into [`ovos-persona`](https://github.com/OpenVoiceOS/ovos-persona) through one well-defined seam. A persona activates exactly one backend with a single line of JSON.
+
+### How to try it
+
+Install the package, pick a backend, and add its `memory_module` key to a persona's JSON file:
+
+```bash
+pip install ovos-memory-plugins
+```
+
+```json
+{
+  "name": "MyAssistant",
+  "solvers": ["ovos-solver-openai-plugin"],
+  "memory_module": "ovos-memory-plugin-recency"
+}
+```
+
+Drop the file in your `ovos-persona` personas directory and the persona starts remembering the last few turns — no models, no extra setup. The sections below cover the other backends, and what to configure for each.
+
+### The seam: one small contract
 
 A memory plugin does not answer questions. The persona still owns the chat engine and any tools; the memory plugin owns **conversation state and context assembly**. Each backend is an `AgentContextManager` from `ovos-plugin-manager`, registered under the `opm.agents.memory` entry-point group, and the whole contract is three methods (`ovos_plugin_manager.templates.agents`):
 
@@ -28,7 +52,7 @@ build_conversation_context(utterance, session_id) -> List[AgentMessage]
 
 Before every turn, the persona calls `build_conversation_context`, sends the returned message list to the chat engine, then calls `update_history` with the new exchange. Two invariants hold for every backend: the first message may be a `system` message carrying the persona's base prompt, and the last message is always the current user utterance. Because the interface is this narrow, backends are interchangeable — swap recall strategies without touching the persona.
 
-## Long-term summarization
+### Long-term summarization
 
 `ovos-memory-plugin-longterm` keeps a compact running summary of a long conversation. Every `summarize_every` exchanges (default 6), it sends the oldest turns to an OpenAI-compatible **chat** endpoint, replaces those turns with the returned summary, and keeps only the last `recent_window` exchanges verbatim. The next turn's context is: system prompt, then rolling summary, then the recent verbatim turns, then the utterance.
 
@@ -54,11 +78,11 @@ This trades exact recall for a bounded, cheap-to-carry context — the gist of a
 }
 ```
 
-## Local-first RAG
+### Local-first RAG
 
 When the assistant needs to recall a specific fact rather than a gist, use `ovos-memory-plugin-local-rag`. It stores every exchange as an embedding in a vector store and, at query time, retrieves the top-k most semantically similar past turns and injects them as context — so relevant history surfaces without the entire transcript overflowing the context window.
 
-"Local" is the point: retrieval runs entirely in-process. The plugin loads an OVOS text-embeddings plugin and an `EmbeddingsDB` plugin directly — no HTTP, no API key. The `local-rag` extra pulls a default offline stack of `ovos-gguf-embeddings-plugin` (a LaBSE GGUF embedding model) and `ovos-chromadb-embeddings-plugin` (a persistent on-disk vector store), so nothing about your conversation history is embedded or searched anywhere but the device it lives on. An earlier server-coupled HTTP variant was removed outright (PR #9) in favor of this local-first design.
+"Local" is the point: retrieval runs entirely in-process. The plugin loads an OVOS text-embeddings plugin and an `EmbeddingsDB` plugin directly — no HTTP, no API key. The `local-rag` extra pulls a default offline stack of `ovos-gguf-embeddings-plugin` (a LaBSE GGUF embedding model) and `ovos-chromadb-embeddings-plugin` (a persistent on-disk vector store), so everything — the embedding and the search — stays on the device. An earlier server-coupled HTTP variant was removed outright (PR #9) in favor of this local-first design.
 
 ```json
 {
@@ -74,18 +98,18 @@ When the assistant needs to recall a specific fact rather than a gist, use `ovos
 
 Retrieved chunks can be woven into the conversation via `inject_mode`: a separate `system` message (the default, which keeps the base prompt stable and cacheable), folded into the system prompt, prepended to the user turn, or — for tool-calling models — presented as a synthetic `search_memory` tool result. The store, the embedding model, and the injection style are all swappable; point `embeddings_db_plugin` at `ovos-qdrant-embeddings-plugin` and the same retrieval logic runs against a shared Qdrant instead.
 
-## Lighter backends, and an ensemble
+### Lighter backends, and an ensemble
 
 Summarization and RAG are the heavyweights. The family also covers cheaper strategies:
 
-- **`ovos-memory-plugin-lexical`** — keyword recall using SQLite's built-in FTS5 index and `bm25()` ranking. No embeddings, no extra dependencies (`sqlite3` is stdlib), fully offline. Use it when the exact term matters more than the meaning.
+- **`ovos-memory-plugin-lexical`** — keyword recall using SQLite's built-in FTS5 index (a full-text search index) and `bm25()` ranking (a formula that scores how well a passage matches search terms). No embeddings, no extra dependencies (`sqlite3` is stdlib), fully offline. Use it when the exact term matters more than the meaning.
 - **`ovos-memory-plugin-recency`** — the lightest option: a sliding window of the most recent turns, bounded by count and optionally by age. No LLM, no embeddings.
 - **`ovos-memory-plugin-entity`** — durable facts about the user (name, preferences, relationships, goals). After each exchange it asks a local OpenAI-compatible endpoint to extract short fact lines and merges them, deduplicated, into a per-session store, then re-injects them every turn. If the endpoint is unreachable, extraction simply no-ops.
-- **`ovos-memory-plugin-composite`** — a pure orchestrator that stores nothing itself. It loads several of the above as members, fuses the retriever hits (RAG + lexical) into one deduplicated ranked list via reciprocal-rank fusion, folds in the summary and facts from the others, and writes every new exchange through to all of them. A member that fails to load or raises is simply skipped. This is how a persona's single `memory_module` slot combines hybrid recall — semantic, keyword, and durable facts at once.
+- **`ovos-memory-plugin-composite`** — a pure orchestrator that stores nothing itself. It loads several of the above as members, fuses the retriever hits (RAG + lexical) into one deduplicated ranked list via reciprocal-rank fusion (a method for merging several ranked lists by each item's position, not its raw score), folds in the summary and facts from the others, and writes every new exchange through to all of them. A member that fails to load or raises is simply skipped. This is how a persona's single `memory_module` slot combines hybrid recall — semantic, keyword, and durable facts at once.
 
 The overview table in the repo lays out the trade-offs: which backends run fully offline, which need a chat endpoint, and how each persists state.
 
-## One config key
+### One config key
 
 Every backend keys its state by `session_id`, so memory is naturally per-session. In a shared household each person's conversation stays separate, and a guest session carries its own — or an empty — window. The persona resolves the backend and its per-plugin config block by name at load time, the same mechanism used for solver configs. Enabling memory is one key:
 


### PR DESCRIPTION
Companion post for ovos-memory-plugins. Code-validated: the 3-method AgentContextManager contract, long-term summarization, local-first RAG (ChromaDB+GGUF, in-process — PR#9 removed the HTTP variant), plus lexical/recency/entity/composite backends. memory_module config verified. No monetary values.