### PR TITLE
blog: 536 in-repo, 835 across the fleet — e2e skill testing with OvoScope

### DIFF
--- a/_posts/2026-09-02-835-tests-later.md
+++ b/_posts/2026-09-02-835-tests-later.md
@@ -1,0 +1,119 @@
+---
+title: "536 Tests In-Repo, 835 Across the Fleet: End-to-End Skill Testing with OvoScope"
+excerpt: "OvoScope runs a full OVOS pipeline in-process — no server, no audio stack, no network. It ships on PyPI as a pytest plugin, and it now underpins the end-to-end test sweep across the default skills. Here is how the framework works and what it verifies."
+coverImage: "/assets/blog/ngi/thumb.png"
+date: "2026-09-02T00:00:00.000Z"
+author:
+  name: JarbasAl
+  picture: "https://avatars.githubusercontent.com/u/33701864"
+ogImage:
+  url: "/assets/blog/ngi/thumb.png"
+---
+
+## Testing a Voice Skill Without a Voice
+
+Testing a voice skill the old way meant standing up a full OVOS instance, wiring up audio hardware, speaking into a microphone, and reading logs to guess whether the right thing happened. Most skill repos never automated any of it. The ones that tried usually mocked the message bus outright, so their tests never ran the actual intent pipeline — the part most likely to break.
+
+[OvoScope](https://github.com/TigreGotico/ovoscope) removes the hardware and the guesswork. It runs a complete OVOS Core pipeline in-process and lets you assert on exactly what the bus produced.
+
+---
+
+## What OvoScope Is
+
+OvoScope loads real skill plugins onto a `FakeBus` — an in-memory stand-in for the OVOS MessageBus — and drives a real `IntentService` and `SkillManager`. No server. No audio stack. No network. You emit a test utterance as a `Message`, and OvoScope captures every message that comes back so you can assert on message *type*, *data* fields, routing *context*, session state, and — importantly — message *order*.
+
+```python
+from ovoscope import End2EndTest
+from ovos_bus_client.message import Message
+from ovos_bus_client.session import Session
+
+session = Session("test-session")
+session.pipeline = ["ovos-adapt-pipeline-plugin-high"]
+
+utterance = Message(
+    "recognizer_loop:utterance",
+    {"utterances": ["what time is it"], "lang": "en-US"},
+    {"session": session.serialize(), "source": "A", "destination": "B"},
+)
+
+End2EndTest(
+    skill_ids=["ovos-skill-date-time.openvoiceos"],
+    source_message=utterance,
+    expected_messages=[
+        utterance,
+        Message("ovos-skill-date-time.openvoiceos:TimeIntent",
+                data={"utterance": "what time is it"}),
+        Message("speak"),
+    ],
+).execute()
+```
+
+Pass that test and you know the real pipeline — real Adapt or Padatious models, the real skill handler, real session context — produced the intent you expected and spoke a response, in that order.
+
+`End2EndTest` is a dataclass with a deep set of knobs, and each one maps to a real failure mode. `eof_msgs` and `eof_count` tell the capture when a dispatch lifecycle is finished (the default terminator is `ovos.utterance.handled`). `ignore_messages` and `ignore_gui` drop noise you are not asserting on. `flip_points`, `entry_points`, and `keep_original_src` verify that `source`/`destination` routing flips correctly as a message travels through the stack. `activation_points` and `deactivation_points` assert which skill is *active* after a given message — the mechanism behind conversational follow-ups. And when two lifecycles interleave non-deterministically (say, a stop request landing mid-dispatch), `skill_id` and `pipeline_id` isolate a single lifecycle so the assertion stays deterministic. You can toggle each sub-check (`test_msg_data`, `test_routing`, `test_active_skills`, …) off individually when a test only cares about one dimension.
+
+---
+
+## The MiniCroft Harness
+
+Underneath `End2EndTest` sits `MiniCroft`, a trimmed `SkillManager` subclass that handles config isolation, skill loading, pipeline initialization, and teardown. OvoScope also ships it as a class-scoped pytest fixture, auto-discovered through the `pytest11` entry point — installing the package is enough to make the fixture available; there is no plugin to register by hand.
+
+Not every skill reacts to an utterance. Timers fire, GUI buttons get pressed, other services publish events. For those, `MiniCroft.inject_message()` emits an arbitrary `Message` straight onto the `FakeBus`, so you can trigger a non-utterance handler and then assert on whatever it emits — no utterance pipeline involved.
+
+For richer assertions, the optional `ovoscope[pydantic]` extra bridges to `ovos-pydantic-models`. Instead of poking at raw dictionaries, you get typed, schema-validated access to message fields — useful when you want to assert that a `speak` message carries the right structure rather than just that it exists.
+
+`MiniCroft` is deliberately not the only harness in the box. PHAL plugins — the hardware-abstraction layer — communicate purely over the bus, so OvoScope ships a separate `MiniPHAL` context manager for testing them without real hardware. There are also dedicated harnesses for the audio, media/OCP, and listener stacks behind their own extras. Each one targets a different layer of OVOS, but they all share the same idea: a `FakeBus`, real components, and assertions on real messages.
+
+---
+
+## Recording Fixtures Instead of Writing Them
+
+Hand-writing the expected message sequence for a complex flow is tedious and error-prone. The `ovoscope` CLI records it for you. `ovoscope record` spins up MiniCroft in-process, sends your utterance, captures the full response sequence, and saves it as a JSON fixture:
+
+```
+ovoscope record --skill-id ovos-skill-hello-world.openvoiceos \
+    --utterance "hello" --output fixture.json
+```
+
+Pass `--live` and it records against an already-running OVOS instance over the real MessageBus instead. Either way the fixture becomes the expected sequence: `ovoscope run fixture.json` replays it and exits non-zero on any mismatch, `ovoscope diff expected.json actual.json` shows exactly what changed with colored output, and `ovoscope validate` schema-checks a fixture. Change a skill, re-run, and see precisely which messages moved.
+
+There is also `ovoscope coverage`, which scans a workspace root and reports which skills have end-to-end tests and which do not — the tool that turns "we should test the skills" into a concrete, trackable list.
+
+---
+
+## The Default Skills QA Sweep
+
+OvoScope's own test suite is substantial — 536 tests covering the framework itself, from the `End2EndTest` assertions to the CLI, the diff engine, the PHAL/audio/media/listener harnesses, and the bus-coverage tracker. But the more interesting number is what happened when the framework was pointed at the skills.
+
+As part of the NGI deliverable work, the default OVOS skills were put through a cross-repo end-to-end sweep built on OvoScope — roughly 835 test cases spread across the default skill set. The sweep checked, per skill:
+
+- **Intent coverage** — does every documented utterance variant reach the intended intent?
+- **Response sequence** — does each handler emit the correct bus messages, in the correct order?
+- **Multi-turn context** — do conversational skills track the active skill across turns?
+- **Session isolation** — do separate sessions keep independent state?
+
+Because the tests run the real pipeline, they surfaced real bugs: intent slots matching partial phrases they shouldn't, responses firing in the wrong order on certain runtime configurations, and context-handling edge cases in multi-turn skills. Each finding got a targeted fix rather than a broad rewrite, and each fix landed with a test that pins the behavior down.
+
+---
+
+## Why This Matters for 1.0
+
+A stable platform needs verifiable behavior, and "probably works" is not verifiable. Because OvoScope drives the actual pipeline and asserts on the actual bus — increasingly against the OVOS message spec via `SpecMessage` — a passing suite is real evidence, not a mock agreeing with itself. It gives OVOS a completeness gate: a skill that ships without a passing OvoScope suite is unverified, full stop. The default-skills sweep sets the baseline for what "verified" means, and because OvoScope is on PyPI and installs as a pytest plugin, every skill repo can run the same suite in CI. Any new PR either keeps the fixtures green or shows exactly what it changed.
+
+---
+
+This work is part of the OpenVoiceOS **From Beta to Breakthrough** milestone, funded through the [NGI0 Commons Fund](https://nlnet.nl/commonsfund), a fund established by [NLnet](https://nlnet.nl) with financial support from the European Commission's [Next Generation Internet](https://ngi.eu) programme, under the aegis of [DG Communications Networks, Content and Technology](https://commission.europa.eu/about-european-commission/departments-and-executive-agencies/communications-networks-content-and-technology_en) under grant agreement No [101135429](https://cordis.europa.eu/project/id/101135429). Additional funding is made available by the [Swiss State Secretariat for Education, Research and Innovation](https://www.sbfi.admin.ch/sbfi/en/home.html) (SERI).
+
+---
+
+## Help Us Build Voice for Everyone
+
+OpenVoiceOS is more than software, it's a mission. If you believe voice assistants should be open, inclusive, and user-controlled, here's how you can help:
+
+- **💸 Donate**: Help us fund development, infrastructure, and legal protection.
+- **📣 Contribute Open Data**: Share voice samples and transcriptions under open licenses.
+- **🌍 Translate**: Help make OVOS accessible in every language.
+
+We're not building this for profit. We're building it for people. With your support, we can keep voice tech transparent, private, and community-owned.
+
+👉 [Support the project here](https://www.openvoiceos.org/contribution)

--- a/_posts/2026-09-02-835-tests-later.md
+++ b/_posts/2026-09-02-835-tests-later.md
@@ -10,17 +10,17 @@ ogImage:
   url: "/assets/blog/ngi/thumb.png"
 ---
 
-## Testing a Voice Skill Without a Voice
+## A skill that "probably works" is not tested
 
-Testing a voice skill the old way meant standing up a full OVOS instance, wiring up audio hardware, speaking into a microphone, and reading logs to guess whether the right thing happened. Most skill repos never automated any of it. The ones that tried usually mocked the message bus outright, so their tests never ran the actual intent pipeline — the part most likely to break.
+Most OVOS skill repos ship without automated tests. The ones that try usually mock the message bus, so the test never runs the real intent pipeline — the part most likely to break. Anything past "did it import" was checked by hand: a real device, a microphone, and someone reading logs to guess whether the right thing happened.
 
-[OvoScope](https://github.com/TigreGotico/ovoscope) removes the hardware and the guesswork. It runs a complete OVOS Core pipeline in-process and lets you assert on exactly what the bus produced.
+[OvoScope](https://github.com/TigreGotico/ovoscope) closes that gap. It runs a complete OVOS Core pipeline in-process and lets you assert on exactly what the message bus produced — no hardware, no server, no guesswork.
 
 ---
 
-## What OvoScope Is
+## What it checks
 
-OvoScope loads real skill plugins onto a `FakeBus` — an in-memory stand-in for the OVOS MessageBus — and drives a real `IntentService` and `SkillManager`. No server. No audio stack. No network. You emit a test utterance as a `Message`, and OvoScope captures every message that comes back so you can assert on message *type*, *data* fields, routing *context*, session state, and — importantly — message *order*.
+OvoScope loads real skill plugins onto a `FakeBus`, an in-memory stand-in for the OVOS MessageBus, and drives a real `IntentService` and `SkillManager`. You send a test utterance as a `Message`. OvoScope captures every message that comes back, so you can assert on message type, data fields, routing context, session state, and message order.
 
 ```python
 from ovoscope import End2EndTest
@@ -48,57 +48,84 @@ End2EndTest(
 ).execute()
 ```
 
-Pass that test and you know the real pipeline — real Adapt or Padatious models, the real skill handler, real session context — produced the intent you expected and spoke a response, in that order.
+Pass that test and you know the real pipeline — real Adapt or Padatious models, the real skill handler, real session context — produced the expected intent and spoke a response, in that order.
 
-`End2EndTest` is a dataclass with a deep set of knobs, and each one maps to a real failure mode. `eof_msgs` and `eof_count` tell the capture when a dispatch lifecycle is finished (the default terminator is `ovos.utterance.handled`). `ignore_messages` and `ignore_gui` drop noise you are not asserting on. `flip_points`, `entry_points`, and `keep_original_src` verify that `source`/`destination` routing flips correctly as a message travels through the stack. `activation_points` and `deactivation_points` assert which skill is *active* after a given message — the mechanism behind conversational follow-ups. And when two lifecycles interleave non-deterministically (say, a stop request landing mid-dispatch), `skill_id` and `pipeline_id` isolate a single lifecycle so the assertion stays deterministic. You can toggle each sub-check (`test_msg_data`, `test_routing`, `test_active_skills`, …) off individually when a test only cares about one dimension.
+`End2EndTest` has a set of knobs, and each one targets a real failure mode:
 
----
+- `eof_msgs` / `eof_count` mark when a dispatch lifecycle is finished (the default terminator is `ovos.utterance.handled`).
+- `ignore_messages` / `ignore_gui` drop noise you are not asserting on.
+- `flip_points`, `entry_points`, and `keep_original_src` check that `source`/`destination` routing flips correctly as a message travels through the stack.
+- `activation_points` / `deactivation_points` assert which skill is active after a given message — the mechanism behind conversational follow-ups.
+- `skill_id` / `pipeline_id` isolate a single lifecycle when two dispatches interleave non-deterministically, such as a stop request landing mid-response.
 
-## The MiniCroft Harness
-
-Underneath `End2EndTest` sits `MiniCroft`, a trimmed `SkillManager` subclass that handles config isolation, skill loading, pipeline initialization, and teardown. OvoScope also ships it as a class-scoped pytest fixture, auto-discovered through the `pytest11` entry point — installing the package is enough to make the fixture available; there is no plugin to register by hand.
-
-Not every skill reacts to an utterance. Timers fire, GUI buttons get pressed, other services publish events. For those, `MiniCroft.inject_message()` emits an arbitrary `Message` straight onto the `FakeBus`, so you can trigger a non-utterance handler and then assert on whatever it emits — no utterance pipeline involved.
-
-For richer assertions, the optional `ovoscope[pydantic]` extra bridges to `ovos-pydantic-models`. Instead of poking at raw dictionaries, you get typed, schema-validated access to message fields — useful when you want to assert that a `speak` message carries the right structure rather than just that it exists.
-
-`MiniCroft` is deliberately not the only harness in the box. PHAL plugins — the hardware-abstraction layer — communicate purely over the bus, so OvoScope ships a separate `MiniPHAL` context manager for testing them without real hardware. There are also dedicated harnesses for the audio, media/OCP, and listener stacks behind their own extras. Each one targets a different layer of OVOS, but they all share the same idea: a `FakeBus`, real components, and assertions on real messages.
+Each sub-check (`test_msg_data`, `test_routing`, `test_active_skills`, and others) can be toggled off individually when a test only needs to cover one dimension.
 
 ---
 
-## Recording Fixtures Instead of Writing Them
+## The harness underneath
 
-Hand-writing the expected message sequence for a complex flow is tedious and error-prone. The `ovoscope` CLI records it for you. `ovoscope record` spins up MiniCroft in-process, sends your utterance, captures the full response sequence, and saves it as a JSON fixture:
+`End2EndTest` runs on `MiniCroft`, a trimmed `SkillManager` subclass that handles config isolation, skill loading, pipeline initialization, and teardown. OvoScope ships it as a class-scoped pytest fixture, auto-discovered through the `pytest11` entry point. Installing the package makes the fixture available — there is no plugin to register by hand.
+
+Not every skill reacts to an utterance. Timers fire, GUI buttons get pressed, other services publish events. For those, `MiniCroft.inject_message()` puts an arbitrary `Message` straight onto the `FakeBus`, so you can trigger a non-utterance handler and assert on whatever it emits.
+
+The optional `ovoscope[pydantic]` extra bridges to `ovos-pydantic-models` for typed, schema-validated access to message fields, instead of raw dictionaries.
+
+`MiniCroft` covers the skill pipeline, but it is not the only harness in the box:
+
+- `MiniPHAL` tests PHAL plugins — the hardware-abstraction layer, which talks purely over the bus — without real hardware.
+- Separate harnesses, behind their own extras, cover the audio, media/OCP, and listener stacks.
+
+Every harness shares the same shape: a `FakeBus`, real components, and assertions on real messages.
+
+---
+
+## Recording fixtures instead of writing them
+
+Hand-writing the expected message sequence for a complex flow is tedious and error-prone. The `ovoscope` CLI records it instead. `ovoscope record` spins up MiniCroft in-process, sends your utterance, captures the full response sequence, and saves it as a JSON fixture:
 
 ```
 ovoscope record --skill-id ovos-skill-hello-world.openvoiceos \
     --utterance "hello" --output fixture.json
 ```
 
-Pass `--live` and it records against an already-running OVOS instance over the real MessageBus instead. Either way the fixture becomes the expected sequence: `ovoscope run fixture.json` replays it and exits non-zero on any mismatch, `ovoscope diff expected.json actual.json` shows exactly what changed with colored output, and `ovoscope validate` schema-checks a fixture. Change a skill, re-run, and see precisely which messages moved.
+Pass `--live` and it records against an already-running OVOS instance over the real MessageBus instead. Either way, the fixture becomes the expected sequence:
 
-There is also `ovoscope coverage`, which scans a workspace root and reports which skills have end-to-end tests and which do not — the tool that turns "we should test the skills" into a concrete, trackable list.
+- `ovoscope run fixture.json` replays it and exits non-zero on any mismatch.
+- `ovoscope diff expected.json actual.json` shows exactly what changed, with colored output.
+- `ovoscope validate` schema-checks a fixture.
+
+Change a skill, re-run, and see exactly which messages moved.
+
+There is also `ovoscope coverage`, which scans a workspace root and reports which skills have end-to-end tests and which do not — turning "we should test the skills" into a concrete, trackable list.
 
 ---
 
-## The Default Skills QA Sweep
+## What the sweep found
 
-OvoScope's own test suite is substantial — 536 tests covering the framework itself, from the `End2EndTest` assertions to the CLI, the diff engine, the PHAL/audio/media/listener harnesses, and the bus-coverage tracker. But the more interesting number is what happened when the framework was pointed at the skills.
+OvoScope's own test suite covers the framework itself — 536 tests, from the `End2EndTest` assertions to the CLI, the diff engine, the PHAL/audio/media/listener harnesses, and the coverage tracker.
 
-As part of the NGI deliverable work, the default OVOS skills were put through a cross-repo end-to-end sweep built on OvoScope — roughly 835 test cases spread across the default skill set. The sweep checked, per skill:
+The more interesting number is what happened when the framework was pointed at the skills. As part of the NGI deliverable work, the default OVOS skills went through a cross-repo end-to-end sweep built on OvoScope: roughly 835 test cases spread across the default skill set. Per skill, the sweep checked:
 
 - **Intent coverage** — does every documented utterance variant reach the intended intent?
 - **Response sequence** — does each handler emit the correct bus messages, in the correct order?
 - **Multi-turn context** — do conversational skills track the active skill across turns?
 - **Session isolation** — do separate sessions keep independent state?
 
-Because the tests run the real pipeline, they surfaced real bugs: intent slots matching partial phrases they shouldn't, responses firing in the wrong order on certain runtime configurations, and context-handling edge cases in multi-turn skills. Each finding got a targeted fix rather than a broad rewrite, and each fix landed with a test that pins the behavior down.
+Because the tests run the real pipeline, they surfaced real bugs: intent slots matching partial phrases they shouldn't, responses firing in the wrong order on certain runtime configurations, and context-handling edge cases in multi-turn skills. Each finding got a targeted fix, and each fix landed with a test that pins the behavior down.
 
 ---
 
-## Why This Matters for 1.0
+## Try it
 
-A stable platform needs verifiable behavior, and "probably works" is not verifiable. Because OvoScope drives the actual pipeline and asserts on the actual bus — increasingly against the OVOS message spec via `SpecMessage` — a passing suite is real evidence, not a mock agreeing with itself. It gives OVOS a completeness gate: a skill that ships without a passing OvoScope suite is unverified, full stop. The default-skills sweep sets the baseline for what "verified" means, and because OvoScope is on PyPI and installs as a pytest plugin, every skill repo can run the same suite in CI. Any new PR either keeps the fixtures green or shows exactly what it changed.
+Install OvoScope and it registers itself as a pytest fixture — nothing to wire up by hand:
+
+```bash
+pip install ovoscope
+```
+
+Write an `End2EndTest` against one of your skill's intents, or record one from a running instance with `ovoscope record`. Either way, you get a fixture you can replay in CI: `ovoscope run fixture.json` fails the build the moment a skill's message sequence changes.
+
+That is the bar this sets for 1.0: a skill that ships without a passing OvoScope suite is unverified, full stop. Because OvoScope is on PyPI and installs as a pytest plugin, any skill repo can run the same suite in CI — increasingly checked against the OVOS message spec via `SpecMessage`. A passing suite is real evidence, not a mock agreeing with itself.
 
 ---
 


### PR DESCRIPTION
Companion post for ovoscope. Code-validated: End2EndTest dataclass knobs, MiniCroft harness (distinct from MiniPHAL), CLI record/run/diff/coverage, [pydantic] extra. Title number honestly split: 536 ovoscope's own tests vs ~835 cross-repo default-skills sweep. No monetary values.