### PR TITLE
blog: The road to 1.0 — V0, V1, V2 (draft)

### DIFF
--- a/_posts/2026-09-16-road-to-v1.md
+++ b/_posts/2026-09-16-road-to-v1.md
@@ -12,17 +12,15 @@ ogImage:
 
 ## The Road to 1.0
 
-Beta software ships features. Stable software ships contracts. The difference is not quality — it is commitment. A stable release means code written against it today keeps working against the next version, and that anyone can verify whether an implementation is correct instead of taking the maintainers' word for it.
+A skill you write today should still run on OVOS three years from now. That is not true yet, because the platform's behaviour has only ever lived in the code — never in a document anyone could check an implementation against. OpenVoiceOS is now writing that document down: a set of versioned, prescriptive specifications that define what the platform *is*, independent of any particular implementation.
 
-OVOS has been in beta for years. The behaviour was real and battle-tested, but it lived in the code, not in any document you could point at. The NGI0 "From Beta to Breakthrough" work exists to change that. One of its deliverables is a formal architecture: a set of versioned, prescriptive specifications that define what the platform *is*, independent of any particular implementation.
+Beta software ships features. Stable software ships contracts. Code written against a contract keeps working against the next version, and anyone can verify whether an implementation is correct without taking the maintainers' word for it. That is the gap this work, part of the NGI0 "From Beta to Breakthrough" milestone, closes.
 
 ---
 
 ## The Architecture Repository
 
-[`OpenVoiceOS/architecture`](https://github.com/OpenVoiceOS/architecture) is the source of truth for how OVOS components talk to each other and what their data shapes mean. It describes a **voice operating system** — not a voice assistant. A voice assistant is a product that answers questions. A voice OS is a platform: it defines the boundary between user input and computation, arbitrates which application handles each utterance, manages conversation state, and provides a stable ABI that arbitrary third-party skills run against without knowing anything about each other.
-
-The repository makes that analogy explicit:
+[`OpenVoiceOS/architecture`](https://github.com/OpenVoiceOS/architecture) is the source of truth for how OVOS components talk to each other and what their data shapes mean. It describes a **voice operating system**, not a voice assistant. A voice assistant answers questions. A voice OS is a platform: it defines the boundary between user input and computation, decides which application handles each utterance, tracks conversation state, and gives arbitrary third-party skills a stable interface to run against without knowing about each other.
 
 | OS concept | Voice OS equivalent |
 |---|---|
@@ -31,51 +29,51 @@ The repository makes that analogy explicit:
 | Process scheduler | Pipeline plugin ordering (PIPELINE-1) |
 | System-call ABI | The `match(utterances, lang, session) → Match` contract |
 
-The specs are grouped into stacks. The **intent stack** (INTENT-1 through INTENT-4) covers what a skill defines — template grammar, locale resource formats, the intent model, and registration. The **bus stack** (MSG-1, SESSION-1, SESSION-2, BRIDGE-1) covers how components communicate. The **orchestrator stack** (PIPELINE-1, plus role specs like CONVERSE-1, CONTEXT-1, STOP-1, FALLBACK-1, COMMON-QUERY-1, PERSONA-1, TRANSFORM-1) covers what processes an utterance. The **I/O and media stacks** (AUDIO-IN-1, AUDIO-1, GUI-1, OCP-1) cover the input and output surfaces.
+The specs are grouped into stacks. The **intent stack** (INTENT-1 through INTENT-4) covers what a skill defines: template grammar, locale resource formats, the intent model, and registration. The **bus stack** (MSG-1, SESSION-1, SESSION-2, BRIDGE-1) covers how components talk to each other. The **orchestrator stack** (PIPELINE-1, plus role specs like CONVERSE-1, CONTEXT-1, STOP-1, FALLBACK-1, COMMON-QUERY-1, PERSONA-1, TRANSFORM-1) covers what processes an utterance. The **I/O and media stacks** (AUDIO-IN-1, AUDIO-1, GUI-1, OCP-1) cover the input and output surfaces.
 
-Every one of these is currently at **Draft** status, and every one is deliberately implementation-agnostic. The specs fix formats and contracts — the observable behaviour — and leave language, internal design, storage, threading, and transport to the implementer. Any voice platform, in any language, can adopt them.
+Every spec here is at **Draft** status, and every one is deliberately implementation-agnostic: it fixes formats and observable behaviour, and leaves language, internal design, storage, threading, and transport to whoever builds it. Any voice platform, in any language, can adopt them.
 
-One consequence matters more than it sounds: these specs are **prescriptive, not descriptive**. They define the intended architecture; they are not a transcript of how today's code behaves. Where an implementation — in OVOS or anywhere else — diverges from a spec, that divergence is a bug in the implementation, not in the specification. Adoption is voluntary; conformance, once adopted, is not.
+One thing matters more than it sounds: these specs are **prescriptive, not descriptive**. They define the intended architecture — they are not a transcript of how today's code behaves. Where an implementation, in OVOS or elsewhere, diverges from a spec, that is a bug in the implementation, not in the spec. Adoption is voluntary; conformance, once adopted, is not.
 
 ---
 
 ## V0, V1, V2: The Compatibility Model
 
-The version number on each spec is not a release counter. It is a **compatibility class**, anchored to the pre-specification behaviour of the stack.
+The version number on a spec is not a release counter. It is a **compatibility class**, measured against the pre-specification behaviour of that stack.
 
 | Class | Meaning |
 |---|---|
-| **V0** | The de-facto, undocumented status quo — the behaviour the stack shipped before a subsystem was formalized. V0 is never written down as a spec; it is the reference point everything else is measured against. |
+| **V0** | The de-facto, undocumented status quo — the behaviour the stack shipped before it was formalized. V0 is never written down as a spec; it is the reference point everything else is measured against. |
 | **V1** | A formalization that stays **compatible with V0**. A V0 component keeps working against a V1 implementation, even if degraded — optional fields tolerated, legacy namespaces honored, reduced guarantees accepted. Same behaviour, now specified and testable. |
 | **V2** | Behaviour that is **not backwards compatible** with V0 — renamed or removed message types, changed payload semantics, consumers that must change before producers. Adopting it requires a coordinated migration. |
 
-The rule of thumb the repository uses: a spec that documents existing flows, adds optional fields, or introduces parallel namespaces while the old ones keep working is V1; a spec that renames, removes, or changes semantics is V2. A single spec may mix the two only if the V2 parts are explicitly gated behind a configuration flag and the ungated behaviour stays V1.
+The rule of thumb: a spec that documents existing flows, adds optional fields, or introduces a parallel namespace while the old one keeps working is V1. A spec that renames, removes, or changes semantics is V2. A single spec can mix both only if the V2 parts sit behind a configuration flag and the ungated behaviour stays V1.
 
-You can read the current state of the migration straight off the spec index. MSG-1, SESSION-1, SESSION-2, TRANSFORM-1, GUI-1, INTENT-3, and OCP-1 sit at V1 — formalized without breaking anything. PIPELINE-1, INTENT-1/2/4, CONVERSE-1, CONTEXT-1, STOP-1, FALLBACK-1, COMMON-QUERY-1, AUDIO-IN-1, AUDIO-1, and BRIDGE-1 have already moved to V2, where the incompatible clean-ups live.
+You can read the migration's current state straight off the spec index. MSG-1, SESSION-1, SESSION-2, TRANSFORM-1, GUI-1, INTENT-3, and OCP-1 are at V1 — formalized without breaking anything. PIPELINE-1, INTENT-1/2/4, CONVERSE-1, CONTEXT-1, STOP-1, FALLBACK-1, COMMON-QUERY-1, AUDIO-IN-1, AUDIO-1, and BRIDGE-1 have already moved to V2, where the incompatible clean-ups live.
 
 ---
 
 ## The `legacy_namespace` Gate
 
-The clearest V2 change in practice is the move away from Mycroft-era bus message names to the new spec namespaces. Because the names differ, this cannot be a compatible V1 change — it is exactly what V2 describes.
+The clearest V2 change in practice is the move away from Mycroft-era bus message names to the new spec namespaces. Because the names differ, this cannot be a compatible V1 change — it is exactly what V2 is for.
 
-The `legacy_namespace` configuration flag is the migration gate. With it enabled, OVOS emits the old Mycroft-compatible message names alongside the new spec names, so a skill that has not been updated keeps working. With it disabled, only the spec names travel the bus. A skill or plugin that has adopted the spec names works either way; one that has not still works while the flag is on. It is a structured, time-boxed migration path, not a permanent shim — which is precisely what makes it a V2 gate rather than open-ended legacy support.
+The `legacy_namespace` configuration flag is the migration gate. With it enabled, OVOS emits the old Mycroft-compatible message names alongside the new spec names, so a skill that has not been updated keeps working. With it disabled, only the spec names travel the bus. A skill or plugin that has adopted the spec names works either way; one that has not still works while the flag is on. It is a structured, time-boxed migration path, not permanent legacy support — which is what makes it a V2 gate.
 
 ---
 
 ## Conformance
 
-A spec without a test is a suggestion. Each specification carries its own conformance section stating what an implementation must satisfy, and where current code diverges the appendix catalogues the known gaps as implementation bugs to be closed. The reference machinery lives in [`ovos-spec-tools`](https://github.com/OpenVoiceOS/ovos-spec-tools) — a dependency-light package providing the sentence-template expander, locale resource loader, dialog renderer, language matching, and the `ovos-spec-lint` linter — and it is the intended home of the shared conformance corpus. Components that would rather not reimplement the spec machinery can simply depend on it.
+A spec without a test is a suggestion. Each specification carries its own conformance section stating what an implementation must satisfy, and an appendix catalogues known gaps in current code as implementation bugs to close. The reference machinery lives in [`ovos-spec-tools`](https://github.com/OpenVoiceOS/ovos-spec-tools): a dependency-light package providing the sentence-template expander, locale resource loader, dialog renderer, language matching, and the `ovos-spec-lint` linter. It is meant to become the shared conformance corpus, and components that would rather not reimplement the spec machinery can just depend on it.
 
-Separately and complementarily, `ovos-pydantic-models` describes the **payload shapes** of bus messages as typed models. That is a different concern from the architecture repository: the specs define component behaviour and the wire contract in prose and RFC-2119 terms, while the pydantic models give producers and consumers a typed, executable description of what a given message's fields are. The two efforts reinforce each other, but the architecture repo is the behavioural source of truth.
+Separately, `ovos-pydantic-models` describes the **payload shapes** of bus messages as typed models. That is a different concern from the architecture repository: the specs define component behaviour and the wire contract in prose and RFC-2119 terms, while the pydantic models give producers and consumers a typed, executable description of a message's fields. The two efforts reinforce each other, but the architecture repo remains the behavioural source of truth.
 
 ---
 
 ## What This Means for Skill and Plugin Authors
 
-Nothing breaks today. The legacy compatibility path stays in place through the transition, so skills that have not been touched keep running. Authors who adopt the new spec message names get a cleaner, more predictable API — and, more importantly, a contract that is written down and enforced, so a skill written now still runs on a conformant OVOS three years from now.
+Nothing breaks today. The legacy compatibility path stays in place through the transition, so skills that have not been touched keep running. Authors who adopt the new spec message names get a cleaner, more predictable API — and a contract that is written down and enforced, so a skill written now still runs on a conformant OVOS years from now.
 
-That is the whole point of the exercise, and it is what "from beta to breakthrough" means as a *measurable* criterion rather than a slogan. The stack starts at V0. Each subsystem is formalized as V1, then migrated to V2 wherever the spec demands an incompatible change, each such change gated so nothing breaks mid-transition. **OVOS is fully spec-compliant when every subsystem operates at V2 — and that state is the 1.0 release criterion.**
+That is the whole point, and it is what "from beta to breakthrough" means as a measurable criterion rather than a slogan. The stack starts at V0. Each subsystem is formalized as V1, then migrated to V2 wherever the spec demands an incompatible change, each change gated so nothing breaks mid-transition. **OVOS is fully spec-compliant when every subsystem operates at V2 — and that state is the 1.0 release criterion.**
 
 ---
 

--- a/_posts/2026-09-16-road-to-v1.md
+++ b/_posts/2026-09-16-road-to-v1.md
@@ -1,6 +1,6 @@
 ---
-title: "The Road to 1.0: Formal Specs, the V0/V1/V2 Versioning Policy, and Conformance"
-excerpt: "OpenVoiceOS is turning years of de-facto behaviour into versioned, prescriptive specifications. This post explains the architecture repository, its V0/V1/V2 compatibility model, the legacy_namespace migration gate, and why 1.0 means every subsystem running at V2."
+title: "Formal Specs, the V0/V1/V2 Versioning Policy, and Conformance (Draft)"
+excerpt: "OpenVoiceOS is turning years of the actual, unwritten behaviour into versioned, prescriptive specifications. This post explains the architecture repository, its V0/V1/V2 compatibility model, the legacy_namespace migration gate, and why 1.0 means every subsystem running at V2."
 coverImage: "/assets/blog/ngi/thumb.png"
 date: "2026-09-16T00:00:00.000Z"
 author:
@@ -18,7 +18,7 @@ If you write an OVOS skill today, nothing guarantees it still runs on OVOS in th
 
 ## The Architecture Repository
 
-`OpenVoiceOS/architecture` describes a **voice operating system**, not a voice assistant. A voice assistant answers questions. A voice OS is a platform: it defines the boundary between user input and computation, decides which application handles each utterance, tracks conversation state, and gives arbitrary third-party skills a stable interface to run against without knowing about each other.
+`OpenVoiceOS/architecture` describes a **voice operating system**: it defines the boundary between user input and computation, decides which application handles each utterance, tracks conversation state, and gives arbitrary third-party skills a stable interface to run against without knowing about each other.
 
 The specs are grouped into stacks. The **intent stack** (INTENT-1 through INTENT-4) covers what a skill defines: template grammar, locale resource formats, the intent model, and registration. The **bus stack** (MSG-1, SESSION-1, SESSION-2, BRIDGE-1) covers how components talk to each other. The **orchestrator stack** (PIPELINE-1, plus role specs like CONVERSE-1, CONTEXT-1, STOP-1, FALLBACK-1, COMMON-QUERY-1, PERSONA-1, TRANSFORM-1) covers what processes an utterance. The **I/O and media stacks** (AUDIO-IN-1, AUDIO-1, GUI-1, OCP-1) cover the input and output surfaces.
 
@@ -34,13 +34,13 @@ The version number on a spec is not a release counter. It is a **compatibility c
 
 | Class | Meaning |
 |---|---|
-| **V0** | The de-facto, undocumented status quo — the behaviour the stack shipped before it was formalized. V0 is never written down as a spec; it is the reference point everything else is measured against. |
+| **V0** | The actual, unwritten behaviour the stack shipped before it was formalized. V0 is never written down as a spec; it is the reference point everything else is measured against. |
 | **V1** | A formalization that stays **compatible with V0**. A V0 component keeps working against a V1 implementation, even if degraded — optional fields tolerated, legacy namespaces honored, reduced guarantees accepted. Same behaviour, now specified and testable. |
 | **V2** | Behaviour that is **not backwards compatible** with V0: renamed or removed message types, changed payload semantics, consumers that must change before producers. Adopting it requires a coordinated migration. |
 
-The rule of thumb: a spec that documents existing flows, adds optional fields, or introduces a parallel namespace while the old one keeps working is V1. A spec that renames, removes, or changes semantics is V2.
+As a general guideline: a spec that documents existing flows, adds optional fields, or introduces a parallel namespace while the old one keeps working is V1. A spec that renames, removes, or changes semantics is V2.
 
-You can read the migration's current state straight off the [spec index](https://github.com/OpenVoiceOS/architecture#readme). MSG-1, SESSION-1, SESSION-2, TRANSFORM-1, GUI-1, INTENT-3, and OCP-1 are at V1 — formalized without breaking anything, but still Draft, so their exact shape can still change before it locks. PIPELINE-1, INTENT-1/2/4, CONVERSE-1, CONTEXT-1, STOP-1, FALLBACK-1, COMMON-QUERY-1, PERSONA-1, AUDIO-IN-1, AUDIO-1, and BRIDGE-1 have already moved to V2, where the incompatible clean-ups live — and being V2 doesn't exempt them from being Draft either.
+You can read the migration's current state directly from the [spec index](https://github.com/OpenVoiceOS/architecture#readme). MSG-1, SESSION-1, SESSION-2, TRANSFORM-1, GUI-1, INTENT-3, and OCP-1 are at V1. They were formalized without breaking anything, but they are still Draft, so their exact shape can still change before it locks. PIPELINE-1, INTENT-1/2/4, CONVERSE-1, CONTEXT-1, STOP-1, FALLBACK-1, COMMON-QUERY-1, PERSONA-1, AUDIO-IN-1, AUDIO-1, and BRIDGE-1 have already moved to V2, where the incompatible clean-ups live. Being V2 does not exempt a spec from also being Draft.
 
 ---
 
@@ -48,7 +48,7 @@ You can read the migration's current state straight off the [spec index](https:/
 
 The clearest V2 change in practice is the move away from Mycroft-era bus message names to the new spec namespaces. Because the names differ, this cannot be a compatible V1 change — it is exactly what V2 is for.
 
-Two separate mechanisms carry that migration. At the service level, the `legacy_namespace` configuration flag — the migration gate named in the [architecture repo's versioning policy](https://github.com/OpenVoiceOS/architecture/blob/dev/VERSIONING.md) — controls which topic a given service, such as `IntentService`, subscribes to: with it on (today's default) the service listens on the legacy topic, with it off it listens on the spec topic instead ([conformance suites flip it off for their run](https://github.com/OpenVoiceOS/ovos-test-harness/blob/dev/docs/writing-conformance-tests.md)). At the bus-client level, a separate pair of flags, `modernize` and `emit_legacy` — [documented in `ovos-bus-client`](https://github.com/OpenVoiceOS/ovos-bus-client/blob/dev/docs/namespace-migration.md) and both on by default — makes `MessageBusClient` emit a migrated event on both the legacy and the `ovos.*` topic at once, so services and skills that have migrated only one side, emit or listen, keep working without coordination; the client also dedups the mirrored copy for handlers subscribed to both. The eventual off-state for those flags, once `ovos.*` predominates, is a later rollout step, not today's default. It is a structured, time-boxed migration path, not permanent legacy support — which is what makes it a V2 gate.
+Two separate mechanisms carry that migration, and per the same Draft caveat as everything else here, either could still change. At the service level, the `legacy_namespace` configuration flag — the migration gate named in the [architecture repo's versioning policy](https://github.com/OpenVoiceOS/architecture/blob/dev/VERSIONING.md) — controls which topic a given service, such as `IntentService`, subscribes to. With it on, which is today's default, the service listens on the legacy topic. With it off, it listens on the spec topic instead. [Conformance suites flip it off for their run](https://github.com/OpenVoiceOS/ovos-test-harness/blob/dev/docs/writing-conformance-tests.md). At the bus-client level, a separate pair of flags, `modernize` and `emit_legacy`, are both on by default and [documented in `ovos-bus-client`](https://github.com/OpenVoiceOS/ovos-bus-client/blob/dev/docs/namespace-migration.md). Together they make `MessageBusClient` emit a migrated event on both the legacy and the `ovos.*` topic at once. This means services and skills that have migrated only one side, emit or listen, keep working without coordination. The client also dedups the mirrored copy for handlers subscribed to both. Turning those flags off is a later rollout step, triggered once `ovos.*` predominates rather than on any fixed date or version — the cited rollout plan defines it as a qualitative, condition-triggered step, not a scheduled one. That open-ended rollout, rather than a scheduled one, is what makes it a V2 gate: legacy support stays until the migration condition is met, not permanently.
 
 ---
 
@@ -63,7 +63,7 @@ pip install ovos-spec-tools
 ovos-spec-lint my-skill/locale
 ```
 
-It reports one line per finding, and its exit code is non-zero on any error, so it drops straight into CI. Run it against real skills and it finds real bugs — camelCase vocabulary file names, legacy `.list` files that predate the current resource-role spec, and similar drift that has been sitting in skill repos unnoticed. Illustrative output, in the linter's actual format:
+It reports one line per finding, and its exit code is non-zero on any error, so it integrates directly into CI. The kinds of issues it catches include camelCase vocabulary file names and legacy `.list` files that predate the current resource-role spec — drift that can go unnoticed in skill repos until a linter names it. The output below is illustrative, in the linter's actual format, not a report from a specific real run:
 
 ```
 $ ovos-spec-lint locale/
@@ -84,7 +84,7 @@ Separately, [`ovos-pydantic-models`](https://github.com/OpenVoiceOS/ovos-pydanti
 
 Nothing breaks today. The legacy compatibility path stays in place through the transition, so skills that have not been touched keep running. Authors who adopt the new spec message names get a cleaner, more predictable API today, and — once the specs now at Draft settle and a subsystem's class stops moving — a written contract to build against for the long term. That is not the case yet: Draft means the compatibility class you read off the index can still change before OVOS reaches 1.0.
 
-The stack starts at V0. Each subsystem is formalized as V1, then migrated to V2 wherever the spec demands an incompatible change, each change gated so nothing breaks mid-transition. Per the [1.0 definition in VERSIONING.md](https://github.com/OpenVoiceOS/architecture/blob/dev/VERSIONING.md#the-10-definition), OVOS is fully spec-compliant, and reaches 1.0, when every subsystem operates at V2. That is the target this work is narrowing the gap toward. It is part of the NGI0 "From Beta to Breakthrough" milestone, and it is not a claim that the gap is closed yet.
+The stack starts at V0. Each subsystem is formalized as V1, then migrated to V2 wherever the spec demands an incompatible change, each change gated so nothing breaks mid-transition. Per the [1.0 definition in VERSIONING.md](https://github.com/OpenVoiceOS/architecture/blob/dev/VERSIONING.md#the-10-definition), OVOS is fully spec-compliant, and reaches 1.0, when every subsystem operates at V2. That is the target this work is reducing the remaining distance to. It is part of the NGI0 "From Beta to Breakthrough" milestone, and it is not a claim that the gap is closed yet.
 
 ---
 
@@ -101,4 +101,4 @@ pip install ovos-spec-tools
 ovos-spec-lint path/to/your-skill/locale
 ```
 
-If a finding looks wrong, or a spec doesn't match what your implementation needs to do, open an issue on [`OpenVoiceOS/architecture`](https://github.com/OpenVoiceOS/architecture/issues) — Draft status means it can still change, and the way it improves is real implementations pushing back on it.
+If a finding looks wrong, or a spec doesn't match what your implementation needs to do, open an issue on [`OpenVoiceOS/architecture`](https://github.com/OpenVoiceOS/architecture/issues) — Draft status means it can still change, and it improves through real implementations giving feedback that leads to changes.

--- a/_posts/2026-09-16-road-to-v1.md
+++ b/_posts/2026-09-16-road-to-v1.md
@@ -36,7 +36,7 @@ The version number on a spec is not a release counter. It is a **compatibility c
 |---|---|
 | **V0** | The de-facto, undocumented status quo — the behaviour the stack shipped before it was formalized. V0 is never written down as a spec; it is the reference point everything else is measured against. |
 | **V1** | A formalization that stays **compatible with V0**. A V0 component keeps working against a V1 implementation, even if degraded — optional fields tolerated, legacy namespaces honored, reduced guarantees accepted. Same behaviour, now specified and testable. |
-| **V2** | Behaviour that is **not backwards compatible** with V0 — renamed or removed message types, changed payload semantics, consumers that must change before producers. Adopting it requires a coordinated migration. |
+| **V2** | Behaviour that is **not backwards compatible** with V0: renamed or removed message types, changed payload semantics, consumers that must change before producers. Adopting it requires a coordinated migration. |
 
 The rule of thumb: a spec that documents existing flows, adds optional fields, or introduces a parallel namespace while the old one keeps working is V1. A spec that renames, removes, or changes semantics is V2.
 
@@ -46,13 +46,13 @@ You can read the migration's current state straight off the [spec index](https:/
 
 ## The `legacy_namespace` Gate
 
-The clearest V2 change in practice is the move away from Mycroft-era bus message names to the new spec namespaces, documented in [`ovos-bus-client`'s namespace migration guide](https://github.com/OpenVoiceOS/ovos-bus-client/blob/dev/docs/namespace-migration.md). Because the names differ, this cannot be a compatible V1 change — it is exactly what V2 is for.
+The clearest V2 change in practice is the move away from Mycroft-era bus message names to the new spec namespaces. Because the names differ, this cannot be a compatible V1 change — it is exactly what V2 is for.
 
-The `legacy_namespace` configuration flag, described in the [architecture repo's versioning policy](https://github.com/OpenVoiceOS/architecture/blob/dev/VERSIONING.md), is the migration gate. With it enabled, OVOS emits the old Mycroft-compatible message names alongside the new spec names, so a skill that has not been updated keeps working. With it disabled, only the spec names travel the bus. A skill or plugin that has adopted the spec names works either way; one that has not still works while the flag is on. It is a structured, time-boxed migration path, not permanent legacy support — which is what makes it a V2 gate.
+Two separate mechanisms carry that migration. At the service level, the `legacy_namespace` configuration flag — the migration gate named in the [architecture repo's versioning policy](https://github.com/OpenVoiceOS/architecture/blob/dev/VERSIONING.md) — controls which topic a given service, such as `IntentService`, subscribes to: with it on (today's default) the service listens on the legacy topic, with it off it listens on the spec topic instead ([conformance suites flip it off for their run](https://github.com/OpenVoiceOS/ovos-test-harness/blob/dev/docs/writing-conformance-tests.md)). At the bus-client level, a separate pair of flags, `modernize` and `emit_legacy` — [documented in `ovos-bus-client`](https://github.com/OpenVoiceOS/ovos-bus-client/blob/dev/docs/namespace-migration.md) and both on by default — makes `MessageBusClient` emit a migrated event on both the legacy and the `ovos.*` topic at once, so services and skills that have migrated only one side, emit or listen, keep working without coordination; the client also dedups the mirrored copy for handlers subscribed to both. The eventual off-state for those flags, once `ovos.*` predominates, is a later rollout step, not today's default. It is a structured, time-boxed migration path, not permanent legacy support — which is what makes it a V2 gate.
 
 ---
 
-## Conformance: Show, Don't Tell
+## Conformance: Testable, Not Just Written
 
 A spec without a test is a suggestion. Each specification carries its own conformance section stating what an implementation must satisfy, and an appendix catalogues known gaps in current code as implementation bugs to close. The reference machinery lives in [`ovos-spec-tools`](https://github.com/OpenVoiceOS/ovos-spec-tools): a dependency-light package providing the sentence-template expander, locale resource loader, dialog renderer, language matching, and the `ovos-spec-lint` linter.
 
@@ -63,9 +63,10 @@ pip install ovos-spec-tools
 ovos-spec-lint my-skill/locale
 ```
 
-It reports one line per finding, and its exit code is non-zero on any error, so it drops straight into CI. Run it against real skills and it finds real bugs — camelCase vocabulary file names, legacy `.list` files that predate the current resource-role spec, and similar drift that has been sitting in skill repos unnoticed:
+It reports one line per finding, and its exit code is non-zero on any error, so it drops straight into CI. Run it against real skills and it finds real bugs — camelCase vocabulary file names, legacy `.list` files that predate the current resource-role spec, and similar drift that has been sitting in skill repos unnoticed. Illustrative output, in the linter's actual format:
 
 ```
+$ ovos-spec-lint locale/
 locale/en-US/CodeResetKeyword.voc: error: base name 'CodeResetKeyword' must be lowercase ASCII letters, digits and underscores only (OVOS-INTENT-2 §2)
 locale/en-US/CodeResetKeyword.voc: warning: file name should be lowercase (OVOS-INTENT-2 §2)
 locale/en-US/items.list: warning: .list is a legacy file type, not an OVOS-INTENT-2 resource role (OVOS-INTENT-2 §1)
@@ -83,7 +84,7 @@ Separately, [`ovos-pydantic-models`](https://github.com/OpenVoiceOS/ovos-pydanti
 
 Nothing breaks today. The legacy compatibility path stays in place through the transition, so skills that have not been touched keep running. Authors who adopt the new spec message names get a cleaner, more predictable API today, and — once the specs now at Draft settle and a subsystem's class stops moving — a written contract to build against for the long term. That is not the case yet: Draft means the compatibility class you read off the index can still change before OVOS reaches 1.0.
 
-The stack starts at V0. Each subsystem is formalized as V1, then migrated to V2 wherever the spec demands an incompatible change, each change gated so nothing breaks mid-transition. Per the [1.0 definition in VERSIONING.md](https://github.com/OpenVoiceOS/architecture/blob/dev/VERSIONING.md#the-10-definition), OVOS is fully spec-compliant, and reaches 1.0, when every subsystem operates at V2. That is the target this work, part of the NGI0 "From Beta to Breakthrough" milestone, is narrowing the gap toward — not a claim that the gap is closed yet.
+The stack starts at V0. Each subsystem is formalized as V1, then migrated to V2 wherever the spec demands an incompatible change, each change gated so nothing breaks mid-transition. Per the [1.0 definition in VERSIONING.md](https://github.com/OpenVoiceOS/architecture/blob/dev/VERSIONING.md#the-10-definition), OVOS is fully spec-compliant, and reaches 1.0, when every subsystem operates at V2. That is the target this work is narrowing the gap toward. It is part of the NGI0 "From Beta to Breakthrough" milestone, and it is not a claim that the gap is closed yet.
 
 ---
 

--- a/_posts/2026-09-16-road-to-v1.md
+++ b/_posts/2026-09-16-road-to-v1.md
@@ -12,26 +12,17 @@ ogImage:
 
 ## The Road to 1.0
 
-A skill you write today should still run on OVOS three years from now. That is not true yet, because the platform's behaviour has only ever lived in the code — never in a document anyone could check an implementation against. OpenVoiceOS is now writing that document down: a set of versioned, prescriptive specifications that define what the platform *is*, independent of any particular implementation.
-
-Beta software ships features. Stable software ships contracts. Code written against a contract keeps working against the next version, and anyone can verify whether an implementation is correct without taking the maintainers' word for it. That is the gap this work, part of the NGI0 "From Beta to Breakthrough" milestone, closes.
+If you write an OVOS skill today, nothing guarantees it still runs on OVOS in three years. The platform's behaviour has only ever lived in the code, never in a document you could check an implementation against. OpenVoiceOS is now writing that document: a set of versioned specifications, at [`OpenVoiceOS/architecture`](https://github.com/OpenVoiceOS/architecture), that define what the platform *is*, independent of any one implementation. Every spec in the repository is still at **Draft** status, which matters: a Draft can still change under adopters, so nothing here is a finished, locked contract yet. This post explains the compatibility model, the current migration state, and how to check an implementation against a spec yourself.
 
 ---
 
 ## The Architecture Repository
 
-[`OpenVoiceOS/architecture`](https://github.com/OpenVoiceOS/architecture) is the source of truth for how OVOS components talk to each other and what their data shapes mean. It describes a **voice operating system**, not a voice assistant. A voice assistant answers questions. A voice OS is a platform: it defines the boundary between user input and computation, decides which application handles each utterance, tracks conversation state, and gives arbitrary third-party skills a stable interface to run against without knowing about each other.
-
-| OS concept | Voice OS equivalent |
-|---|---|
-| IPC / message passing | The bus and the MSG-1 envelope |
-| Shared memory | Session carrier (SESSION-1, SESSION-2) |
-| Process scheduler | Pipeline plugin ordering (PIPELINE-1) |
-| System-call ABI | The `match(utterances, lang, session) → Match` contract |
+`OpenVoiceOS/architecture` describes a **voice operating system**, not a voice assistant. A voice assistant answers questions. A voice OS is a platform: it defines the boundary between user input and computation, decides which application handles each utterance, tracks conversation state, and gives arbitrary third-party skills a stable interface to run against without knowing about each other.
 
 The specs are grouped into stacks. The **intent stack** (INTENT-1 through INTENT-4) covers what a skill defines: template grammar, locale resource formats, the intent model, and registration. The **bus stack** (MSG-1, SESSION-1, SESSION-2, BRIDGE-1) covers how components talk to each other. The **orchestrator stack** (PIPELINE-1, plus role specs like CONVERSE-1, CONTEXT-1, STOP-1, FALLBACK-1, COMMON-QUERY-1, PERSONA-1, TRANSFORM-1) covers what processes an utterance. The **I/O and media stacks** (AUDIO-IN-1, AUDIO-1, GUI-1, OCP-1) cover the input and output surfaces.
 
-Every spec here is at **Draft** status, and every one is deliberately implementation-agnostic: it fixes formats and observable behaviour, and leaves language, internal design, storage, threading, and transport to whoever builds it. Any voice platform, in any language, can adopt them.
+Every spec is deliberately implementation-agnostic: it fixes formats and observable behaviour, and leaves language, internal design, storage, threading, and transport to whoever builds it. Any voice platform, in any language, can adopt them.
 
 One thing matters more than it sounds: these specs are **prescriptive, not descriptive**. They define the intended architecture — they are not a transcript of how today's code behaves. Where an implementation, in OVOS or elsewhere, diverges from a spec, that is a bug in the implementation, not in the spec. Adoption is voluntary; conformance, once adopted, is not.
 
@@ -39,7 +30,7 @@ One thing matters more than it sounds: these specs are **prescriptive, not descr
 
 ## V0, V1, V2: The Compatibility Model
 
-The version number on a spec is not a release counter. It is a **compatibility class**, measured against the pre-specification behaviour of that stack.
+The version number on a spec is not a release counter. It is a **compatibility class**, measured against the pre-specification behaviour of that stack. Because every spec is Draft, the class itself can still move as a spec is revised — V1 today does not guarantee V1 tomorrow.
 
 | Class | Meaning |
 |---|---|
@@ -47,33 +38,52 @@ The version number on a spec is not a release counter. It is a **compatibility c
 | **V1** | A formalization that stays **compatible with V0**. A V0 component keeps working against a V1 implementation, even if degraded — optional fields tolerated, legacy namespaces honored, reduced guarantees accepted. Same behaviour, now specified and testable. |
 | **V2** | Behaviour that is **not backwards compatible** with V0 — renamed or removed message types, changed payload semantics, consumers that must change before producers. Adopting it requires a coordinated migration. |
 
-The rule of thumb: a spec that documents existing flows, adds optional fields, or introduces a parallel namespace while the old one keeps working is V1. A spec that renames, removes, or changes semantics is V2. A single spec can mix both only if the V2 parts sit behind a configuration flag and the ungated behaviour stays V1.
+The rule of thumb: a spec that documents existing flows, adds optional fields, or introduces a parallel namespace while the old one keeps working is V1. A spec that renames, removes, or changes semantics is V2.
 
-You can read the migration's current state straight off the spec index. MSG-1, SESSION-1, SESSION-2, TRANSFORM-1, GUI-1, INTENT-3, and OCP-1 are at V1 — formalized without breaking anything. PIPELINE-1, INTENT-1/2/4, CONVERSE-1, CONTEXT-1, STOP-1, FALLBACK-1, COMMON-QUERY-1, AUDIO-IN-1, AUDIO-1, and BRIDGE-1 have already moved to V2, where the incompatible clean-ups live.
+You can read the migration's current state straight off the [spec index](https://github.com/OpenVoiceOS/architecture#readme). MSG-1, SESSION-1, SESSION-2, TRANSFORM-1, GUI-1, INTENT-3, and OCP-1 are at V1 — formalized without breaking anything, but still Draft, so their exact shape can still change before it locks. PIPELINE-1, INTENT-1/2/4, CONVERSE-1, CONTEXT-1, STOP-1, FALLBACK-1, COMMON-QUERY-1, PERSONA-1, AUDIO-IN-1, AUDIO-1, and BRIDGE-1 have already moved to V2, where the incompatible clean-ups live — and being V2 doesn't exempt them from being Draft either.
 
 ---
 
 ## The `legacy_namespace` Gate
 
-The clearest V2 change in practice is the move away from Mycroft-era bus message names to the new spec namespaces. Because the names differ, this cannot be a compatible V1 change — it is exactly what V2 is for.
+The clearest V2 change in practice is the move away from Mycroft-era bus message names to the new spec namespaces, documented in [`ovos-bus-client`'s namespace migration guide](https://github.com/OpenVoiceOS/ovos-bus-client/blob/dev/docs/namespace-migration.md). Because the names differ, this cannot be a compatible V1 change — it is exactly what V2 is for.
 
-The `legacy_namespace` configuration flag is the migration gate. With it enabled, OVOS emits the old Mycroft-compatible message names alongside the new spec names, so a skill that has not been updated keeps working. With it disabled, only the spec names travel the bus. A skill or plugin that has adopted the spec names works either way; one that has not still works while the flag is on. It is a structured, time-boxed migration path, not permanent legacy support — which is what makes it a V2 gate.
+The `legacy_namespace` configuration flag, described in the [architecture repo's versioning policy](https://github.com/OpenVoiceOS/architecture/blob/dev/VERSIONING.md), is the migration gate. With it enabled, OVOS emits the old Mycroft-compatible message names alongside the new spec names, so a skill that has not been updated keeps working. With it disabled, only the spec names travel the bus. A skill or plugin that has adopted the spec names works either way; one that has not still works while the flag is on. It is a structured, time-boxed migration path, not permanent legacy support — which is what makes it a V2 gate.
 
 ---
 
-## Conformance
+## Conformance: Show, Don't Tell
 
-A spec without a test is a suggestion. Each specification carries its own conformance section stating what an implementation must satisfy, and an appendix catalogues known gaps in current code as implementation bugs to close. The reference machinery lives in [`ovos-spec-tools`](https://github.com/OpenVoiceOS/ovos-spec-tools): a dependency-light package providing the sentence-template expander, locale resource loader, dialog renderer, language matching, and the `ovos-spec-lint` linter. It is meant to become the shared conformance corpus, and components that would rather not reimplement the spec machinery can just depend on it.
+A spec without a test is a suggestion. Each specification carries its own conformance section stating what an implementation must satisfy, and an appendix catalogues known gaps in current code as implementation bugs to close. The reference machinery lives in [`ovos-spec-tools`](https://github.com/OpenVoiceOS/ovos-spec-tools): a dependency-light package providing the sentence-template expander, locale resource loader, dialog renderer, language matching, and the `ovos-spec-lint` linter.
 
-Separately, `ovos-pydantic-models` describes the **payload shapes** of bus messages as typed models. That is a different concern from the architecture repository: the specs define component behaviour and the wire contract in prose and RFC-2119 terms, while the pydantic models give producers and consumers a typed, executable description of a message's fields. The two efforts reinforce each other, but the architecture repo remains the behavioural source of truth.
+Install it and point it at a skill's `locale/` folder:
+
+```bash
+pip install ovos-spec-tools
+ovos-spec-lint my-skill/locale
+```
+
+It reports one line per finding, and its exit code is non-zero on any error, so it drops straight into CI. Run it against real skills and it finds real bugs — camelCase vocabulary file names, legacy `.list` files that predate the current resource-role spec, and similar drift that has been sitting in skill repos unnoticed:
+
+```
+locale/en-US/CodeResetKeyword.voc: error: base name 'CodeResetKeyword' must be lowercase ASCII letters, digits and underscores only (OVOS-INTENT-2 §2)
+locale/en-US/CodeResetKeyword.voc: warning: file name should be lowercase (OVOS-INTENT-2 §2)
+locale/en-US/items.list: warning: .list is a legacy file type, not an OVOS-INTENT-2 resource role (OVOS-INTENT-2 §1)
+
+2 error(s), 1 warning(s)
+```
+
+That is the difference between a spec and a suggestion: a linter that names the exact clause a file violates, and a non-zero exit code a CI pipeline can gate on.
+
+Separately, [`ovos-pydantic-models`](https://github.com/OpenVoiceOS/ovos-pydantic-models) describes the **payload shapes** of bus messages as typed Python models. That is a different concern from the architecture repository: the specs define component behaviour and the wire contract in prose and RFC-2119 terms (standardized requirement language — MUST, SHOULD, MAY, defined in [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119)), while the pydantic models give producers and consumers a typed, executable description of a message's fields. The two efforts reinforce each other, but the architecture repo remains the behavioural source of truth.
 
 ---
 
 ## What This Means for Skill and Plugin Authors
 
-Nothing breaks today. The legacy compatibility path stays in place through the transition, so skills that have not been touched keep running. Authors who adopt the new spec message names get a cleaner, more predictable API — and a contract that is written down and enforced, so a skill written now still runs on a conformant OVOS years from now.
+Nothing breaks today. The legacy compatibility path stays in place through the transition, so skills that have not been touched keep running. Authors who adopt the new spec message names get a cleaner, more predictable API today, and — once the specs now at Draft settle and a subsystem's class stops moving — a written contract to build against for the long term. That is not the case yet: Draft means the compatibility class you read off the index can still change before OVOS reaches 1.0.
 
-That is the whole point, and it is what "from beta to breakthrough" means as a measurable criterion rather than a slogan. The stack starts at V0. Each subsystem is formalized as V1, then migrated to V2 wherever the spec demands an incompatible change, each change gated so nothing breaks mid-transition. **OVOS is fully spec-compliant when every subsystem operates at V2 — and that state is the 1.0 release criterion.**
+The stack starts at V0. Each subsystem is formalized as V1, then migrated to V2 wherever the spec demands an incompatible change, each change gated so nothing breaks mid-transition. Per the [1.0 definition in VERSIONING.md](https://github.com/OpenVoiceOS/architecture/blob/dev/VERSIONING.md#the-10-definition), OVOS is fully spec-compliant, and reaches 1.0, when every subsystem operates at V2. That is the target this work, part of the NGI0 "From Beta to Breakthrough" milestone, is narrowing the gap toward — not a claim that the gap is closed yet.
 
 ---
 
@@ -81,14 +91,13 @@ This work is part of the OpenVoiceOS **From Beta to Breakthrough** milestone, fu
 
 ---
 
-## Help Us Build Voice for Everyone
+## Try It Yourself
 
-OpenVoiceOS is more than software, it's a mission. If you believe voice assistants should be open, inclusive, and user-controlled, here's how you can help:
+Point `ovos-spec-lint` at your own skill's `locale/` folder and see what it finds:
 
-- **💸 Donate**: Help us fund development, infrastructure, and legal protection.
-- **📣 Contribute Open Data**: Share voice samples and transcriptions under open licenses.
-- **🌍 Translate**: Help make OVOS accessible in every language.
+```bash
+pip install ovos-spec-tools
+ovos-spec-lint path/to/your-skill/locale
+```
 
-We're not building this for profit. We're building it for people. With your support, we can keep voice tech transparent, private, and community-owned.
-
-👉 [Support the project here](https://www.openvoiceos.org/contribution)
+If a finding looks wrong, or a spec doesn't match what your implementation needs to do, open an issue on [`OpenVoiceOS/architecture`](https://github.com/OpenVoiceOS/architecture/issues) — Draft status means it can still change, and the way it improves is real implementations pushing back on it.

--- a/_posts/2026-09-16-road-to-v1.md
+++ b/_posts/2026-09-16-road-to-v1.md
@@ -1,0 +1,96 @@
+---
+title: "The Road to 1.0: Formal Specs, the V0/V1/V2 Versioning Policy, and Conformance"
+excerpt: "OpenVoiceOS is turning years of de-facto behaviour into versioned, prescriptive specifications. This post explains the architecture repository, its V0/V1/V2 compatibility model, the legacy_namespace migration gate, and why 1.0 means every subsystem running at V2."
+coverImage: "/assets/blog/ngi/thumb.png"
+date: "2026-09-16T00:00:00.000Z"
+author:
+  name: JarbasAl
+  picture: "https://avatars.githubusercontent.com/u/33701864"
+ogImage:
+  url: "/assets/blog/ngi/thumb.png"
+---
+
+## The Road to 1.0
+
+Beta software ships features. Stable software ships contracts. The difference is not quality — it is commitment. A stable release means code written against it today keeps working against the next version, and that anyone can verify whether an implementation is correct instead of taking the maintainers' word for it.
+
+OVOS has been in beta for years. The behaviour was real and battle-tested, but it lived in the code, not in any document you could point at. The NGI0 "From Beta to Breakthrough" work exists to change that. One of its deliverables is a formal architecture: a set of versioned, prescriptive specifications that define what the platform *is*, independent of any particular implementation.
+
+---
+
+## The Architecture Repository
+
+[`OpenVoiceOS/architecture`](https://github.com/OpenVoiceOS/architecture) is the source of truth for how OVOS components talk to each other and what their data shapes mean. It describes a **voice operating system** — not a voice assistant. A voice assistant is a product that answers questions. A voice OS is a platform: it defines the boundary between user input and computation, arbitrates which application handles each utterance, manages conversation state, and provides a stable ABI that arbitrary third-party skills run against without knowing anything about each other.
+
+The repository makes that analogy explicit:
+
+| OS concept | Voice OS equivalent |
+|---|---|
+| IPC / message passing | The bus and the MSG-1 envelope |
+| Shared memory | Session carrier (SESSION-1, SESSION-2) |
+| Process scheduler | Pipeline plugin ordering (PIPELINE-1) |
+| System-call ABI | The `match(utterances, lang, session) → Match` contract |
+
+The specs are grouped into stacks. The **intent stack** (INTENT-1 through INTENT-4) covers what a skill defines — template grammar, locale resource formats, the intent model, and registration. The **bus stack** (MSG-1, SESSION-1, SESSION-2, BRIDGE-1) covers how components communicate. The **orchestrator stack** (PIPELINE-1, plus role specs like CONVERSE-1, CONTEXT-1, STOP-1, FALLBACK-1, COMMON-QUERY-1, PERSONA-1, TRANSFORM-1) covers what processes an utterance. The **I/O and media stacks** (AUDIO-IN-1, AUDIO-1, GUI-1, OCP-1) cover the input and output surfaces.
+
+Every one of these is currently at **Draft** status, and every one is deliberately implementation-agnostic. The specs fix formats and contracts — the observable behaviour — and leave language, internal design, storage, threading, and transport to the implementer. Any voice platform, in any language, can adopt them.
+
+One consequence matters more than it sounds: these specs are **prescriptive, not descriptive**. They define the intended architecture; they are not a transcript of how today's code behaves. Where an implementation — in OVOS or anywhere else — diverges from a spec, that divergence is a bug in the implementation, not in the specification. Adoption is voluntary; conformance, once adopted, is not.
+
+---
+
+## V0, V1, V2: The Compatibility Model
+
+The version number on each spec is not a release counter. It is a **compatibility class**, anchored to the pre-specification behaviour of the stack.
+
+| Class | Meaning |
+|---|---|
+| **V0** | The de-facto, undocumented status quo — the behaviour the stack shipped before a subsystem was formalized. V0 is never written down as a spec; it is the reference point everything else is measured against. |
+| **V1** | A formalization that stays **compatible with V0**. A V0 component keeps working against a V1 implementation, even if degraded — optional fields tolerated, legacy namespaces honored, reduced guarantees accepted. Same behaviour, now specified and testable. |
+| **V2** | Behaviour that is **not backwards compatible** with V0 — renamed or removed message types, changed payload semantics, consumers that must change before producers. Adopting it requires a coordinated migration. |
+
+The rule of thumb the repository uses: a spec that documents existing flows, adds optional fields, or introduces parallel namespaces while the old ones keep working is V1; a spec that renames, removes, or changes semantics is V2. A single spec may mix the two only if the V2 parts are explicitly gated behind a configuration flag and the ungated behaviour stays V1.
+
+You can read the current state of the migration straight off the spec index. MSG-1, SESSION-1, SESSION-2, TRANSFORM-1, GUI-1, INTENT-3, and OCP-1 sit at V1 — formalized without breaking anything. PIPELINE-1, INTENT-1/2/4, CONVERSE-1, CONTEXT-1, STOP-1, FALLBACK-1, COMMON-QUERY-1, AUDIO-IN-1, AUDIO-1, and BRIDGE-1 have already moved to V2, where the incompatible clean-ups live.
+
+---
+
+## The `legacy_namespace` Gate
+
+The clearest V2 change in practice is the move away from Mycroft-era bus message names to the new spec namespaces. Because the names differ, this cannot be a compatible V1 change — it is exactly what V2 describes.
+
+The `legacy_namespace` configuration flag is the migration gate. With it enabled, OVOS emits the old Mycroft-compatible message names alongside the new spec names, so a skill that has not been updated keeps working. With it disabled, only the spec names travel the bus. A skill or plugin that has adopted the spec names works either way; one that has not still works while the flag is on. It is a structured, time-boxed migration path, not a permanent shim — which is precisely what makes it a V2 gate rather than open-ended legacy support.
+
+---
+
+## Conformance
+
+A spec without a test is a suggestion. Each specification carries its own conformance section stating what an implementation must satisfy, and where current code diverges the appendix catalogues the known gaps as implementation bugs to be closed. The reference machinery lives in [`ovos-spec-tools`](https://github.com/OpenVoiceOS/ovos-spec-tools) — a dependency-light package providing the sentence-template expander, locale resource loader, dialog renderer, language matching, and the `ovos-spec-lint` linter — and it is the intended home of the shared conformance corpus. Components that would rather not reimplement the spec machinery can simply depend on it.
+
+Separately and complementarily, `ovos-pydantic-models` describes the **payload shapes** of bus messages as typed models. That is a different concern from the architecture repository: the specs define component behaviour and the wire contract in prose and RFC-2119 terms, while the pydantic models give producers and consumers a typed, executable description of what a given message's fields are. The two efforts reinforce each other, but the architecture repo is the behavioural source of truth.
+
+---
+
+## What This Means for Skill and Plugin Authors
+
+Nothing breaks today. The legacy compatibility path stays in place through the transition, so skills that have not been touched keep running. Authors who adopt the new spec message names get a cleaner, more predictable API — and, more importantly, a contract that is written down and enforced, so a skill written now still runs on a conformant OVOS three years from now.
+
+That is the whole point of the exercise, and it is what "from beta to breakthrough" means as a *measurable* criterion rather than a slogan. The stack starts at V0. Each subsystem is formalized as V1, then migrated to V2 wherever the spec demands an incompatible change, each such change gated so nothing breaks mid-transition. **OVOS is fully spec-compliant when every subsystem operates at V2 — and that state is the 1.0 release criterion.**
+
+---
+
+This work is part of the OpenVoiceOS **From Beta to Breakthrough** milestone, funded through the [NGI0 Commons Fund](https://nlnet.nl/commonsfund), a fund established by [NLnet](https://nlnet.nl) with financial support from the European Commission's [Next Generation Internet](https://ngi.eu) programme, under the aegis of [DG Communications Networks, Content and Technology](https://commission.europa.eu/about-european-commission/departments-and-executive-agencies/communications-networks-content-and-technology_en) under grant agreement No [101135429](https://cordis.europa.eu/project/id/101135429). Additional funding is made available by the [Swiss State Secretariat for Education, Research and Innovation](https://www.sbfi.admin.ch/sbfi/en/home.html) (SERI).
+
+---
+
+## Help Us Build Voice for Everyone
+
+OpenVoiceOS is more than software, it's a mission. If you believe voice assistants should be open, inclusive, and user-controlled, here's how you can help:
+
+- **💸 Donate**: Help us fund development, infrastructure, and legal protection.
+- **📣 Contribute Open Data**: Share voice samples and transcriptions under open licenses.
+- **🌍 Translate**: Help make OVOS accessible in every language.
+
+We're not building this for profit. We're building it for people. With your support, we can keep voice tech transparent, private, and community-owned.
+
+👉 [Support the project here](https://www.openvoiceos.org/contribution)


### PR DESCRIPTION
Companion post for the architecture repo's versioning/conformance story. Code-validated against VERSIONING.md + spec index: **1.0 = every subsystem at V2**, per-spec V0/V1/V2 classes, legacy_namespace as the V2 gate, ovos-spec-tools as reference machinery. Keeps ovos-pydantic-models (payload shapes) explicitly distinct from the architecture specs (behaviour). No monetary values.