### PR TITLE
blog: Train your own wake word (WakeForge + public notebook)

### DIFF
--- a/_posts/2026-10-21-train-your-own-wakeword.md
+++ b/_posts/2026-10-21-train-your-own-wakeword.md
@@ -20,19 +20,19 @@ Two NGI0-funded deliverables close that gap: **WakeForge**, a wake-word trainer 
 
 A wake-word detector answers one question thousands of times a second: did someone just say the phrase, or not? Training it needs two kinds of audio. **Positive samples** are recordings of the wake phrase itself. **Negative audio** is everything else — speech, background noise, music — so the model learns what to ignore.
 
-Negatives are easy to collect; the world is full of audio that isn't your wake word. Positives are the bottleneck. A robust detector traditionally wants hundreds or thousands of recordings of the exact phrase, spoken by many voices in many conditions. ww-trainer states the design target for a useful detector as better than ~90% recall, without false-triggering more than once per hour. No individual user records that much data. That data problem is why "just train your own" was never a real option before.
+Negatives are easy to collect; the world is full of audio that isn't your wake word. Positives are the bottleneck. A robust detector traditionally wants hundreds or thousands of recordings of the exact phrase. Those recordings need to come from many voices in many conditions. ww-trainer states the design target for a useful detector as better than ~90% recall, without false-triggering more than once per hour. No individual user records that much data. That data problem is why "just train your own" was never a real option before.
 
 ---
 
 ## What WakeForge Is
 
-[WakeForge](https://github.com/TigreGotico/wakeforge) is a research-grade training suite for wake-word detection. The repo's own README and CLI still call it **ww-trainer** / "Wake Word Trainer" throughout — WakeForge is the newer name used by the runtime plugin and the docs, so don't be surprised to see both in the wild. It isn't one fixed model — it's an experimentation surface: **11 built-in featurizers × 15 classifier heads × 15 loss functions**, driven by genetic and Bayesian hyperparameter search, plus 12 notebooks covering the pipeline from data prep to export. A researcher can sweep architectures and losses; a user can skip all of that and run one notebook.
+[WakeForge](https://github.com/TigreGotico/wakeforge) is a research-grade training suite for wake-word detection. The repo's own README and CLI still call it **ww-trainer** / "Wake Word Trainer" throughout — WakeForge is the newer name used by the runtime plugin and the docs, so you may see either name used in the repo and docs. It isn't one fixed model — it's an experimentation surface: **11 built-in featurizers × 15 classifier heads × 15 loss functions**, driven by genetic and Bayesian hyperparameter search, plus 12 notebooks covering the pipeline from data prep to export. A researcher can sweep architectures and losses; a user can skip all of that and run one notebook.
 
 Every component exports to ONNX, so the trained models run anywhere: inference needs only `onnxruntime` and `numpy`, no PyTorch on the device. Detectors span hardware tiers from `esp32_nano` (sub-1 KB, int8) up to `hubert_medium`, so the same suite targets a microcontroller or a GPU server.
 
-The trick behind small-data training is **frozen self-supervised featurizers**. Self-supervised speech models — HuBERT, Wav2Vec2-BERT — already learned general representations of human speech from large amounts of unlabeled audio. WakeForge uses these as pre-exported ONNX front-ends and keeps them frozen, training only a small classifier head on top. (The HuBERT path has its own notebook, `nb08_wakehubert.ipynb`, if you want to look under the hood.)
+The trick behind small-data training is **frozen self-supervised featurizers**. Self-supervised speech models — HuBERT, Wav2Vec2-BERT — already learned general representations of human speech from large amounts of unlabeled audio. WakeForge uses these as pre-exported ONNX front-ends and keeps them frozen, training only a small classifier head on top. (The HuBERT path has its own notebook, `nb08_wakehubert.ipynb`, if you want to see how it works internally.)
 
-Because the speech understanding is already done, that head needs far less of your own data. Freezing the featurizer also keeps training and inference features identical — the trade-off, stated plainly by the project, is that a frozen featurizer can't adapt to your data the way a fully-trained one could.
+Because the speech understanding is already done, that head needs far less of your own data. Freezing the featurizer also keeps training and inference features identical. The trade-off, stated plainly by the project, is that a frozen featurizer can't adapt to your data the way a fully-trained one could.
 
 ## Solving the Data Problem
 
@@ -50,7 +50,11 @@ The project's own caveat: synthetic data is good for getting a model working and
 
 The [public quickstart notebook](https://github.com/TigreGotico/wakeforge/blob/dev/notebooks/kaggle_quickstart.ipynb) — `kaggle_quickstart` — is the user-facing entry point. It runs on a free Colab or Kaggle GPU (a T4, a common free-tier cloud graphics card), so you need only a browser; a full run takes roughly 25–40 minutes.
 
-If you'd rather skip the notebook, the same flow is a CLI script, though it's not a single install-and-run command yet: clone the repo, install it with the `datagen` and `torchcodec` extras, then call the quickstart script.
+If you'd rather skip the notebook, the same flow is available as a CLI script. It's not a single install-and-run command yet:
+
+1. Clone the repo.
+2. Install it with the `datagen` and `torchcodec` extras.
+3. Call the quickstart script.
 
 ```bash
 git clone https://github.com/TigreGotico/wakeforge
@@ -76,11 +80,19 @@ The flow underneath:
    - via the ovos-ww-plugin-wakeforge runtime plugin
 ```
 
-Step 5 is the step users most often get wrong. A WakeForge model is a **featurizer + head ONNX pair**, and the plugin that loads exactly that pair is **[ovos-ww-plugin-wakeforge](https://github.com/OpenVoiceOS/ovos-ww-plugin-wakeforge)**. In `mycroft.conf`, point one hotword at the two files (local paths or URLs) and set a detection `threshold`. The plugin handles the rest: score smoothing, a `patience` count of consecutive frames before firing, a debounce interval (a minimum gap enforced between repeat firings), an optional VAD (voice activity detection — a separate check for "is anyone speaking at all") channel, and a stateful streaming GRU (a small recurrent neural-network layer that keeps a memory of recent audio) head. WakeForge exports use their own format — they don't drop into the Precise, microWakeWord, or wakewordlab plugins, which each load different model types.
+Step 5 is the step users most often get wrong. A WakeForge model is a **featurizer + head ONNX pair**, and the plugin that loads exactly that pair is **[ovos-ww-plugin-wakeforge](https://github.com/OpenVoiceOS/ovos-ww-plugin-wakeforge)**. In `mycroft.conf`, point one hotword at the two files (local paths or URLs) and set a detection `threshold`. The plugin handles the rest:
+
+- Score smoothing.
+- A `patience` count of consecutive frames before firing.
+- A debounce interval — a minimum gap enforced between repeat firings.
+- An optional VAD (voice activity detection — a separate check for "is anyone speaking at all") channel.
+- A stateful streaming GRU (a small recurrent neural-network layer that keeps a memory of recent audio) head.
+
+WakeForge exports use their own format — they don't drop into the Precise, microWakeWord, or wakewordlab plugins, which each load different model types.
 
 ## Why This Matters
 
-Wake words used to be fixed: your assistant answered only to the phrases someone else picked and trained for you. Local, user-trainable wake words change that: pick any name, in any language, and keep the whole pipeline offline, because detection runs entirely on your device — no cloud service ever hears your phrase.
+Wake words used to be fixed: your assistant answered only to the phrases someone else picked and trained for you. Local, user-trainable wake words change that: pick any name, in any language, and detection runs entirely on your device once the model is trained — no cloud service hears your phrase at that stage. Training itself, using the recommended notebook flow, does run on cloud GPUs, and synthetic data generation calls a cloud TTS service, so the pipeline as a whole is not offline end-to-end — only inference is.
 
 Results depend on your data and your phrase, and a production detector still wants some real recordings; we're not claiming otherwise. What's changed is the barrier: training a custom wake word is no longer a research project, it's a notebook you can open right now, and one entry in a wider collection of OVOS training notebooks for wake words, voices, and intents.
 

--- a/_posts/2026-10-21-train-your-own-wakeword.md
+++ b/_posts/2026-10-21-train-your-own-wakeword.md
@@ -20,13 +20,13 @@ Two NGI0-funded deliverables close that gap: **WakeForge**, a wake-word trainer 
 
 A wake-word detector answers one question thousands of times a second: did someone just say the phrase, or not? Training it needs two kinds of audio. **Positive samples** are recordings of the wake phrase itself. **Negative audio** is everything else — speech, background noise, music — so the model learns what to ignore.
 
-Negatives are easy to collect; the world is full of audio that isn't your wake word. Positives are the bottleneck. A robust detector traditionally wants hundreds or thousands of recordings of the exact phrase, spoken by many voices in many conditions, to fire reliably (better than ~90% recall) without false-triggering (under one false alarm per hour). No individual user records that much. That data problem is why "just train your own" was never a real option before.
+Negatives are easy to collect; the world is full of audio that isn't your wake word. Positives are the bottleneck. A robust detector traditionally wants hundreds or thousands of recordings of the exact phrase, spoken by many voices in many conditions. ww-trainer states the design target for a useful detector as better than ~90% recall, without false-triggering more than once per hour. No individual user records that much data. That data problem is why "just train your own" was never a real option before.
 
 ---
 
 ## What WakeForge Is
 
-[WakeForge](https://github.com/TigreGotico/ww-trainer) is a research-grade training suite for wake-word detection. It isn't one fixed model — it's an experimentation surface: **11 built-in featurizers × 15 classifier heads × 15 loss functions**, driven by genetic and Bayesian hyperparameter search, plus 12 notebooks covering the pipeline from data prep to export. A researcher can sweep architectures and losses; a user can skip all of that and run one notebook.
+[WakeForge](https://github.com/TigreGotico/wakeforge) is a research-grade training suite for wake-word detection. The repo's own README and CLI still call it **ww-trainer** / "Wake Word Trainer" throughout — WakeForge is the newer name used by the runtime plugin and the docs, so don't be surprised to see both in the wild. It isn't one fixed model — it's an experimentation surface: **11 built-in featurizers × 15 classifier heads × 15 loss functions**, driven by genetic and Bayesian hyperparameter search, plus 12 notebooks covering the pipeline from data prep to export. A researcher can sweep architectures and losses; a user can skip all of that and run one notebook.
 
 Every component exports to ONNX, so the trained models run anywhere: inference needs only `onnxruntime` and `numpy`, no PyTorch on the device. Detectors span hardware tiers from `esp32_nano` (sub-1 KB, int8) up to `hubert_medium`, so the same suite targets a microcontroller or a GPU server.
 
@@ -39,7 +39,7 @@ Because the speech understanding is already done, that head needs far less of yo
 Better features lower the bar, but you still need some positives and plenty of negatives. WakeForge ships both:
 
 - **[Synthetic dataset generator](https://github.com/TigreGotico/synthetic_dataset_generator)** — no recordings of your phrase? Generate them with TTS plus pure-ONNX voice conversion ([voiceclonnx](https://github.com/TigreGotico/voiceclonnx)), synthesizing positives across many voices and styles. Ready-made [synthetic wake-word datasets](https://huggingface.co/collections/TigreGotico/synthetic-wakeword-datasets) are published as examples.
-- **[notwakeword datasets](https://huggingface.co/collections/TigreGotico/notwakeword-datasets)** — curated negative/background collections, so you don't assemble hours of "everything except the wake word" yourself. Larger runs add hard-negative mining on top.
+- **[notwakeword datasets](https://huggingface.co/collections/TigreGotico/notwakeword-datasets)** — curated negative/background collections, so you don't assemble hours of "everything except the wake word" yourself. Larger runs add hard-negative mining on top (training on extra negatives that sound close to the wake word, so the model learns the fine distinctions).
 - **[ONNX feature extractors](https://huggingface.co/collections/TigreGotico/onnx-feature-extractors)** — the frozen self-supervised front-ends, exported so training and runtime use the same features.
 
 The project's own caveat: synthetic data is good for getting a model working and smoke-testing it, but a wake word you rely on every day still benefits from some real, far-field recordings in the mix.
@@ -50,11 +50,14 @@ The project's own caveat: synthetic data is good for getting a model working and
 
 The [public quickstart notebook](https://github.com/TigreGotico/wakeforge/blob/dev/notebooks/kaggle_quickstart.ipynb) — `kaggle_quickstart` — is the user-facing entry point. It runs on a free Colab or Kaggle GPU (a T4, a common free-tier cloud graphics card), so you need only a browser; a full run takes roughly 25–40 minutes.
 
-If you'd rather skip the notebook and use a terminal, the same flow is one CLI call:
+If you'd rather skip the notebook, the same flow is a CLI script, though it's not a single install-and-run command yet: clone the repo, install it with the `datagen` and `torchcodec` extras, then call the quickstart script.
 
 ```bash
+git clone https://github.com/TigreGotico/wakeforge
+cd wakeforge
+uv pip install -e ".[dev,datagen,torchcodec]"
 ww_trainer-quickstart --wake-word "hey jarvis" --output-dir ./hey_jarvis
-# -> ./hey_jarvis/best_f1_featurizer.onnx  +  ./hey_jarvis/best_f1.onnx
+# -> ./hey_jarvis/model/best_f1.onnx  (featurizer alongside it under model/)
 ```
 
 The flow underneath:
@@ -68,12 +71,12 @@ The flow underneath:
 3. Train
    - Frozen SSL featurizer -> small classifier head
 4. Export to ONNX
-   - Produces a featurizer .onnx + a head .onnx (best_f1_featurizer.onnx + best_f1.onnx)
+   - Produces a featurizer .onnx + a head .onnx
 5. Load it in OVOS
    - via the ovos-ww-plugin-wakeforge runtime plugin
 ```
 
-Step 5 is where it's easy to trip up. A WakeForge model is a **featurizer + head ONNX pair**, and the plugin that loads exactly that pair is **[ovos-ww-plugin-wakeforge](https://github.com/OpenVoiceOS/ovos-ww-plugin-wakeforge)**. In `mycroft.conf`, point one hotword at the two files (local paths or URLs) and set a detection `threshold`. The plugin handles the rest: score smoothing, a `patience` count of consecutive frames before firing, a debounce interval, an optional VAD (voice activity detection — a separate check for "is anyone speaking at all") channel, and a stateful streaming GRU (a small recurrent neural-network layer that keeps a memory of recent audio) head. WakeForge exports use their own format — they don't drop into the Precise, microWakeWord, or wakewordlab plugins, which each load different model types.
+Step 5 is the step users most often get wrong. A WakeForge model is a **featurizer + head ONNX pair**, and the plugin that loads exactly that pair is **[ovos-ww-plugin-wakeforge](https://github.com/OpenVoiceOS/ovos-ww-plugin-wakeforge)**. In `mycroft.conf`, point one hotword at the two files (local paths or URLs) and set a detection `threshold`. The plugin handles the rest: score smoothing, a `patience` count of consecutive frames before firing, a debounce interval (a minimum gap enforced between repeat firings), an optional VAD (voice activity detection — a separate check for "is anyone speaking at all") channel, and a stateful streaming GRU (a small recurrent neural-network layer that keeps a memory of recent audio) head. WakeForge exports use their own format — they don't drop into the Precise, microWakeWord, or wakewordlab plugins, which each load different model types.
 
 ## Why This Matters
 

--- a/_posts/2026-10-21-train-your-own-wakeword.md
+++ b/_posts/2026-10-21-train-your-own-wakeword.md
@@ -1,0 +1,98 @@
+---
+title: "Train Your Own Wake Word for OVOS: WakeForge and a Notebook Anyone Can Run"
+excerpt: "Custom wake words have always been gated by data — especially recordings of your chosen phrase. WakeForge, a research-grade training suite, tackles this with frozen self-supervised featurizers and a public Colab/Kaggle notebook, so any user can train a personal wake word for their own name, language, or secret phrase."
+coverImage: "/assets/blog/ngi/thumb.png"
+date: "2026-10-21T00:00:00.000Z"
+author:
+  name: JarbasAl
+  picture: "https://avatars.githubusercontent.com/u/33701864"
+ogImage:
+  url: "/assets/blog/ngi/thumb.png"
+---
+
+## Train Your Own Wake Word for OVOS
+
+Saying "Hey Mycroft" works fine, until you want your assistant to answer to something else. Maybe you want it to wake to your own name, a word in your language, or a private phrase nobody else would guess. On paper, a wake word is a tiny model — the exported files are typically under 1 MB. In practice, training one has always been out of reach for most users, and the reason is almost always data.
+
+Two NGI0-funded deliverables are now complete: the wake-word trainer R&D suite — **WakeForge** — and a **public, user-facing wake-word training notebook**. Together they make custom wake words something you can build yourself, on free cloud hardware, without a machine-learning background.
+
+## Why Custom Wake Words Are Hard
+
+A wake-word detector answers one question thousands of times per second: *did someone just say the phrase, or not?* To learn that, it needs two kinds of audio. First, **positive samples** — recordings of the wake phrase itself. Second, **negative audio** — lots of speech, background noise, music, and everyday sound that is *not* the wake word, so the model learns what to ignore.
+
+Collecting negatives is tedious but easy; there is endless audio in the world that isn't your wake word. The real bottleneck is positives. A robust detector traditionally wants hundreds or thousands of recordings of the exact phrase, spoken by many voices, in many conditions — enough to fire reliably (better than ~90% recall) while almost never false-triggering (under one false alarm per hour). No individual user is going to record that. This single data problem is why "just train your own" has never been a real answer, until now.
+
+---
+
+## What WakeForge Is
+
+[WakeForge](https://github.com/TigreGotico/ww-trainer) is a research-grade training suite for wake-word detection. It is not one fixed model — it's a whole experimentation surface: **11 built-in featurizers × 15 classifier heads × 15 loss functions**, driven by genetic and Bayesian hyperparameter search, plus 12 notebooks that document the full pipeline from data prep to export. A researcher can sweep architectures and losses; a user can ignore all of that and run one notebook.
+
+Every component exports to ONNX, and that is the point that makes the models deployable everywhere: runtime inference needs only `onnxruntime` and `numpy` — no PyTorch on the device. Trained detectors span hardware tiers from `esp32_nano` (sub-1 KB, int8) up to `hubert_medium`, so the same suite targets an ESP32 microcontroller or a GPU server.
+
+The trick that makes small-data training work is **frozen self-supervised featurizers**. Self-supervised speech models — like HuBERT and Wav2Vec2-BERT — have already learned rich, general representations of human speech from large amounts of unlabeled audio. WakeForge uses these as pre-exported ONNX front-ends and keeps them **frozen**, training only a small classifier head on top. (The HuBERT path has its own notebook, `nb08_wakehubert.ipynb`, if you want to look under the hood.)
+
+Because the heavy lifting of understanding speech is already done, that little head needs far less of your own data to reach a usable result. Freezing the featurizer also guarantees the features are identical at training and inference time — the honest trade-off, which the project states plainly, being that a frozen featurizer can't adapt to your data the way a fully-trained one could.
+
+## Solving the Data Problem
+
+Better features lower the bar, but you still need *some* positives and plenty of negatives. WakeForge ships the pieces to get both:
+
+- **[Synthetic dataset generator](https://github.com/TigreGotico/synthetic_dataset_generator)** — when you have zero recordings of your phrase, generate them. It uses TTS plus pure-ONNX voice conversion ([voiceclonnx](https://github.com/TigreGotico/voiceclonnx)) to synthesize positive samples across many voices and styles. Ready-made [synthetic wake-word datasets](https://huggingface.co/collections/TigreGotico/synthetic-wakeword-datasets) are published as examples.
+- **[notwakeword datasets](https://huggingface.co/collections/TigreGotico/notwakeword-datasets)** — curated negative/background collections, so you don't have to assemble hours of "everything except the wake word" yourself. For larger runs the suite adds hard-negative mining on top.
+- **[ONNX feature extractors](https://huggingface.co/collections/TigreGotico/onnx-feature-extractors)** — the frozen self-supervised front-ends, exported to ONNX so the same features used in training are available efficiently at runtime.
+
+A fair warning the project makes itself: synthetic data is excellent for getting a model working and smoke-testing it, but a wake word you rely on every day still benefits from some **real, far-field recordings** in the mix.
+
+---
+
+## Train It Yourself
+
+The [public quickstart notebook](https://github.com/TigreGotico/ww-trainer/pull/20) — `kaggle_quickstart` — is the user-facing entry point. It runs on a free Colab or Kaggle GPU, so you need nothing more than a browser; a full run takes roughly 25–40 minutes on a free Kaggle T4. On the command line it collapses to a single string:
+
+```bash
+wakeforge-quickstart "hey jarvis" ./hey_jarvis
+# -> ./hey_jarvis/best_f1_featurizer.onnx  +  ./hey_jarvis/best_f1.onnx
+```
+
+Under the hood, the flow is:
+
+```text
+1. Bring or generate positives
+   - Record a handful of samples of your phrase, OR
+   - Use the synthetic generator to create them with TTS / voice conversion
+2. Pick negatives
+   - Grab a notwakeword dataset for background/speech audio
+3. Train
+   - Frozen SSL featurizer -> small classifier head
+4. Export to ONNX
+   - Produces a featurizer .onnx + a head .onnx (best_f1_featurizer.onnx + best_f1.onnx)
+5. Load it in OVOS
+   - via the ovos-ww-plugin-wakeforge runtime plugin
+```
+
+Step 5 is the part it's easy to get wrong: a WakeForge model is a **featurizer + head ONNX pair**, and the plugin built to load exactly that pair is **[ovos-ww-plugin-wakeforge](https://github.com/OpenVoiceOS/ovos-ww-plugin-wakeforge)**. In `mycroft.conf` you point one hotword at the two files (local paths or URLs) and set a detection `threshold`; the plugin adds the runtime niceties a real always-on detector needs — score smoothing, a `patience` count of consecutive frames before firing, a debounce interval, an optional VAD channel, and a stateful streaming GRU head. Point it at your exported files and your assistant starts listening for *your* word. (WakeForge exports are their own format — they aren't drop-in for the Precise, microWakeWord, or wakewordlab plugins, which each load their own model types.)
+
+## Why This Matters
+
+Wake words are the front door to a voice assistant, and until now that door came with a fixed set of keys. Local, user-trainable wake words change that. You can pick any name, in any language, and keep the whole pipeline offline — no cloud service ever hears your phrase, because detection runs entirely on your device. Personal, private, and yours to name.
+
+We didn't invent accuracy claims here, and we won't; results depend on your data and your phrase, and a production detector still wants some real recordings. What we *can* say is that the barrier has moved. Training a custom wake word is no longer a research project. It's a notebook you can open right now — and it's one entry in a wider collection of OVOS training notebooks for wake words, voices, and intents.
+
+---
+
+This work is part of the OpenVoiceOS **From Beta to Breakthrough** milestone, funded through the [NGI0 Commons Fund](https://nlnet.nl/commonsfund), a fund established by [NLnet](https://nlnet.nl) with financial support from the European Commission's [Next Generation Internet](https://ngi.eu) programme, under the aegis of [DG Communications Networks, Content and Technology](https://commission.europa.eu/about-european-commission/departments-and-executive-agencies/communications-networks-content-and-technology_en) under grant agreement No [101135429](https://cordis.europa.eu/project/id/101135429). Additional funding is made available by the [Swiss State Secretariat for Education, Research and Innovation](https://www.sbfi.admin.ch/sbfi/en/home.html) (SERI).
+
+---
+
+## Help Us Build Voice for Everyone
+
+OpenVoiceOS is more than software, it's a mission. If you believe voice assistants should be open, inclusive, and user-controlled, here's how you can help:
+
+- **💸 Donate**: Help us fund development, infrastructure, and legal protection.
+- **📣 Contribute Open Data**: Share voice samples and transcriptions under open licenses.
+- **🌍 Translate**: Help make OVOS accessible in every language.
+
+We're not building this for profit. We're building it for people. With your support, we can keep voice tech transparent, private, and community-owned.
+
+👉 [Support the project here](https://www.openvoiceos.org/contribution)

--- a/_posts/2026-10-21-train-your-own-wakeword.md
+++ b/_posts/2026-10-21-train-your-own-wakeword.md
@@ -10,7 +10,7 @@ ogImage:
   url: "/assets/blog/ngi/thumb.png"
 ---
 
-## Train Your Own Wake Word for OVOS
+## From Notebook to Wake Word
 
 "Hey Mycroft" works fine, until you want your assistant to answer to your own name, a word in your language, or a private phrase nobody else would guess. A wake-word model is tiny — the exported files usually run under 1 MB. Training one has always been out of reach for most users anyway, because it takes data you don't have.
 
@@ -48,10 +48,12 @@ The project's own caveat: synthetic data is good for getting a model working and
 
 ## Train It Yourself
 
-The [public quickstart notebook](https://github.com/TigreGotico/ww-trainer/pull/20) — `kaggle_quickstart` — is the user-facing entry point. It runs on a free Colab or Kaggle GPU, so you need only a browser; a full run takes roughly 25–40 minutes on a free Kaggle T4. On the command line it's one call:
+The [public quickstart notebook](https://github.com/TigreGotico/wakeforge/blob/dev/notebooks/kaggle_quickstart.ipynb) — `kaggle_quickstart` — is the user-facing entry point. It runs on a free Colab or Kaggle GPU (a T4, a common free-tier cloud graphics card), so you need only a browser; a full run takes roughly 25–40 minutes.
+
+If you'd rather skip the notebook and use a terminal, the same flow is one CLI call:
 
 ```bash
-wakeforge-quickstart "hey jarvis" ./hey_jarvis
+ww_trainer-quickstart --wake-word "hey jarvis" --output-dir ./hey_jarvis
 # -> ./hey_jarvis/best_f1_featurizer.onnx  +  ./hey_jarvis/best_f1.onnx
 ```
 
@@ -71,11 +73,11 @@ The flow underneath:
    - via the ovos-ww-plugin-wakeforge runtime plugin
 ```
 
-Step 5 is where it's easy to trip up. A WakeForge model is a **featurizer + head ONNX pair**, and the plugin that loads exactly that pair is **[ovos-ww-plugin-wakeforge](https://github.com/OpenVoiceOS/ovos-ww-plugin-wakeforge)**. In `mycroft.conf`, point one hotword at the two files (local paths or URLs) and set a detection `threshold`. The plugin handles the rest: score smoothing, a `patience` count of consecutive frames before firing, a debounce interval, an optional VAD channel, and a stateful streaming GRU head. WakeForge exports use their own format — they don't drop into the Precise, microWakeWord, or wakewordlab plugins, which each load different model types.
+Step 5 is where it's easy to trip up. A WakeForge model is a **featurizer + head ONNX pair**, and the plugin that loads exactly that pair is **[ovos-ww-plugin-wakeforge](https://github.com/OpenVoiceOS/ovos-ww-plugin-wakeforge)**. In `mycroft.conf`, point one hotword at the two files (local paths or URLs) and set a detection `threshold`. The plugin handles the rest: score smoothing, a `patience` count of consecutive frames before firing, a debounce interval, an optional VAD (voice activity detection — a separate check for "is anyone speaking at all") channel, and a stateful streaming GRU (a small recurrent neural-network layer that keeps a memory of recent audio) head. WakeForge exports use their own format — they don't drop into the Precise, microWakeWord, or wakewordlab plugins, which each load different model types.
 
 ## Why This Matters
 
-Wake words are the front door to a voice assistant, and until now that door came with a fixed set of keys. Local, user-trainable wake words change that: pick any name, in any language, and keep the whole pipeline offline, because detection runs entirely on your device — no cloud service ever hears your phrase.
+Wake words used to be fixed: your assistant answered only to the phrases someone else picked and trained for you. Local, user-trainable wake words change that: pick any name, in any language, and keep the whole pipeline offline, because detection runs entirely on your device — no cloud service ever hears your phrase.
 
 Results depend on your data and your phrase, and a production detector still wants some real recordings; we're not claiming otherwise. What's changed is the barrier: training a custom wake word is no longer a research project, it's a notebook you can open right now, and one entry in a wider collection of OVOS training notebooks for wake words, voices, and intents.
 

--- a/_posts/2026-10-21-train-your-own-wakeword.md
+++ b/_posts/2026-10-21-train-your-own-wakeword.md
@@ -12,50 +12,50 @@ ogImage:
 
 ## Train Your Own Wake Word for OVOS
 
-Saying "Hey Mycroft" works fine, until you want your assistant to answer to something else. Maybe you want it to wake to your own name, a word in your language, or a private phrase nobody else would guess. On paper, a wake word is a tiny model — the exported files are typically under 1 MB. In practice, training one has always been out of reach for most users, and the reason is almost always data.
+"Hey Mycroft" works fine, until you want your assistant to answer to your own name, a word in your language, or a private phrase nobody else would guess. A wake-word model is tiny — the exported files usually run under 1 MB. Training one has always been out of reach for most users anyway, because it takes data you don't have.
 
-Two NGI0-funded deliverables are now complete: the wake-word trainer R&D suite — **WakeForge** — and a **public, user-facing wake-word training notebook**. Together they make custom wake words something you can build yourself, on free cloud hardware, without a machine-learning background.
+Two NGI0-funded deliverables close that gap: **WakeForge**, a wake-word trainer R&D suite, and a public, user-facing training notebook. Together they let you build a custom wake word yourself, on free cloud hardware, with no machine-learning background.
 
 ## Why Custom Wake Words Are Hard
 
-A wake-word detector answers one question thousands of times per second: *did someone just say the phrase, or not?* To learn that, it needs two kinds of audio. First, **positive samples** — recordings of the wake phrase itself. Second, **negative audio** — lots of speech, background noise, music, and everyday sound that is *not* the wake word, so the model learns what to ignore.
+A wake-word detector answers one question thousands of times a second: did someone just say the phrase, or not? Training it needs two kinds of audio. **Positive samples** are recordings of the wake phrase itself. **Negative audio** is everything else — speech, background noise, music — so the model learns what to ignore.
 
-Collecting negatives is tedious but easy; there is endless audio in the world that isn't your wake word. The real bottleneck is positives. A robust detector traditionally wants hundreds or thousands of recordings of the exact phrase, spoken by many voices, in many conditions — enough to fire reliably (better than ~90% recall) while almost never false-triggering (under one false alarm per hour). No individual user is going to record that. This single data problem is why "just train your own" has never been a real answer, until now.
+Negatives are easy to collect; the world is full of audio that isn't your wake word. Positives are the bottleneck. A robust detector traditionally wants hundreds or thousands of recordings of the exact phrase, spoken by many voices in many conditions, to fire reliably (better than ~90% recall) without false-triggering (under one false alarm per hour). No individual user records that much. That data problem is why "just train your own" was never a real option before.
 
 ---
 
 ## What WakeForge Is
 
-[WakeForge](https://github.com/TigreGotico/ww-trainer) is a research-grade training suite for wake-word detection. It is not one fixed model — it's a whole experimentation surface: **11 built-in featurizers × 15 classifier heads × 15 loss functions**, driven by genetic and Bayesian hyperparameter search, plus 12 notebooks that document the full pipeline from data prep to export. A researcher can sweep architectures and losses; a user can ignore all of that and run one notebook.
+[WakeForge](https://github.com/TigreGotico/ww-trainer) is a research-grade training suite for wake-word detection. It isn't one fixed model — it's an experimentation surface: **11 built-in featurizers × 15 classifier heads × 15 loss functions**, driven by genetic and Bayesian hyperparameter search, plus 12 notebooks covering the pipeline from data prep to export. A researcher can sweep architectures and losses; a user can skip all of that and run one notebook.
 
-Every component exports to ONNX, and that is the point that makes the models deployable everywhere: runtime inference needs only `onnxruntime` and `numpy` — no PyTorch on the device. Trained detectors span hardware tiers from `esp32_nano` (sub-1 KB, int8) up to `hubert_medium`, so the same suite targets an ESP32 microcontroller or a GPU server.
+Every component exports to ONNX, so the trained models run anywhere: inference needs only `onnxruntime` and `numpy`, no PyTorch on the device. Detectors span hardware tiers from `esp32_nano` (sub-1 KB, int8) up to `hubert_medium`, so the same suite targets a microcontroller or a GPU server.
 
-The trick that makes small-data training work is **frozen self-supervised featurizers**. Self-supervised speech models — like HuBERT and Wav2Vec2-BERT — have already learned rich, general representations of human speech from large amounts of unlabeled audio. WakeForge uses these as pre-exported ONNX front-ends and keeps them **frozen**, training only a small classifier head on top. (The HuBERT path has its own notebook, `nb08_wakehubert.ipynb`, if you want to look under the hood.)
+The trick behind small-data training is **frozen self-supervised featurizers**. Self-supervised speech models — HuBERT, Wav2Vec2-BERT — already learned general representations of human speech from large amounts of unlabeled audio. WakeForge uses these as pre-exported ONNX front-ends and keeps them frozen, training only a small classifier head on top. (The HuBERT path has its own notebook, `nb08_wakehubert.ipynb`, if you want to look under the hood.)
 
-Because the heavy lifting of understanding speech is already done, that little head needs far less of your own data to reach a usable result. Freezing the featurizer also guarantees the features are identical at training and inference time — the honest trade-off, which the project states plainly, being that a frozen featurizer can't adapt to your data the way a fully-trained one could.
+Because the speech understanding is already done, that head needs far less of your own data. Freezing the featurizer also keeps training and inference features identical — the trade-off, stated plainly by the project, is that a frozen featurizer can't adapt to your data the way a fully-trained one could.
 
 ## Solving the Data Problem
 
-Better features lower the bar, but you still need *some* positives and plenty of negatives. WakeForge ships the pieces to get both:
+Better features lower the bar, but you still need some positives and plenty of negatives. WakeForge ships both:
 
-- **[Synthetic dataset generator](https://github.com/TigreGotico/synthetic_dataset_generator)** — when you have zero recordings of your phrase, generate them. It uses TTS plus pure-ONNX voice conversion ([voiceclonnx](https://github.com/TigreGotico/voiceclonnx)) to synthesize positive samples across many voices and styles. Ready-made [synthetic wake-word datasets](https://huggingface.co/collections/TigreGotico/synthetic-wakeword-datasets) are published as examples.
-- **[notwakeword datasets](https://huggingface.co/collections/TigreGotico/notwakeword-datasets)** — curated negative/background collections, so you don't have to assemble hours of "everything except the wake word" yourself. For larger runs the suite adds hard-negative mining on top.
-- **[ONNX feature extractors](https://huggingface.co/collections/TigreGotico/onnx-feature-extractors)** — the frozen self-supervised front-ends, exported to ONNX so the same features used in training are available efficiently at runtime.
+- **[Synthetic dataset generator](https://github.com/TigreGotico/synthetic_dataset_generator)** — no recordings of your phrase? Generate them with TTS plus pure-ONNX voice conversion ([voiceclonnx](https://github.com/TigreGotico/voiceclonnx)), synthesizing positives across many voices and styles. Ready-made [synthetic wake-word datasets](https://huggingface.co/collections/TigreGotico/synthetic-wakeword-datasets) are published as examples.
+- **[notwakeword datasets](https://huggingface.co/collections/TigreGotico/notwakeword-datasets)** — curated negative/background collections, so you don't assemble hours of "everything except the wake word" yourself. Larger runs add hard-negative mining on top.
+- **[ONNX feature extractors](https://huggingface.co/collections/TigreGotico/onnx-feature-extractors)** — the frozen self-supervised front-ends, exported so training and runtime use the same features.
 
-A fair warning the project makes itself: synthetic data is excellent for getting a model working and smoke-testing it, but a wake word you rely on every day still benefits from some **real, far-field recordings** in the mix.
+The project's own caveat: synthetic data is good for getting a model working and smoke-testing it, but a wake word you rely on every day still benefits from some real, far-field recordings in the mix.
 
 ---
 
 ## Train It Yourself
 
-The [public quickstart notebook](https://github.com/TigreGotico/ww-trainer/pull/20) — `kaggle_quickstart` — is the user-facing entry point. It runs on a free Colab or Kaggle GPU, so you need nothing more than a browser; a full run takes roughly 25–40 minutes on a free Kaggle T4. On the command line it collapses to a single string:
+The [public quickstart notebook](https://github.com/TigreGotico/ww-trainer/pull/20) — `kaggle_quickstart` — is the user-facing entry point. It runs on a free Colab or Kaggle GPU, so you need only a browser; a full run takes roughly 25–40 minutes on a free Kaggle T4. On the command line it's one call:
 
 ```bash
 wakeforge-quickstart "hey jarvis" ./hey_jarvis
 # -> ./hey_jarvis/best_f1_featurizer.onnx  +  ./hey_jarvis/best_f1.onnx
 ```
 
-Under the hood, the flow is:
+The flow underneath:
 
 ```text
 1. Bring or generate positives
@@ -71,13 +71,13 @@ Under the hood, the flow is:
    - via the ovos-ww-plugin-wakeforge runtime plugin
 ```
 
-Step 5 is the part it's easy to get wrong: a WakeForge model is a **featurizer + head ONNX pair**, and the plugin built to load exactly that pair is **[ovos-ww-plugin-wakeforge](https://github.com/OpenVoiceOS/ovos-ww-plugin-wakeforge)**. In `mycroft.conf` you point one hotword at the two files (local paths or URLs) and set a detection `threshold`; the plugin adds the runtime niceties a real always-on detector needs — score smoothing, a `patience` count of consecutive frames before firing, a debounce interval, an optional VAD channel, and a stateful streaming GRU head. Point it at your exported files and your assistant starts listening for *your* word. (WakeForge exports are their own format — they aren't drop-in for the Precise, microWakeWord, or wakewordlab plugins, which each load their own model types.)
+Step 5 is where it's easy to trip up. A WakeForge model is a **featurizer + head ONNX pair**, and the plugin that loads exactly that pair is **[ovos-ww-plugin-wakeforge](https://github.com/OpenVoiceOS/ovos-ww-plugin-wakeforge)**. In `mycroft.conf`, point one hotword at the two files (local paths or URLs) and set a detection `threshold`. The plugin handles the rest: score smoothing, a `patience` count of consecutive frames before firing, a debounce interval, an optional VAD channel, and a stateful streaming GRU head. WakeForge exports use their own format — they don't drop into the Precise, microWakeWord, or wakewordlab plugins, which each load different model types.
 
 ## Why This Matters
 
-Wake words are the front door to a voice assistant, and until now that door came with a fixed set of keys. Local, user-trainable wake words change that. You can pick any name, in any language, and keep the whole pipeline offline — no cloud service ever hears your phrase, because detection runs entirely on your device. Personal, private, and yours to name.
+Wake words are the front door to a voice assistant, and until now that door came with a fixed set of keys. Local, user-trainable wake words change that: pick any name, in any language, and keep the whole pipeline offline, because detection runs entirely on your device — no cloud service ever hears your phrase.
 
-We didn't invent accuracy claims here, and we won't; results depend on your data and your phrase, and a production detector still wants some real recordings. What we *can* say is that the barrier has moved. Training a custom wake word is no longer a research project. It's a notebook you can open right now — and it's one entry in a wider collection of OVOS training notebooks for wake words, voices, and intents.
+Results depend on your data and your phrase, and a production detector still wants some real recordings; we're not claiming otherwise. What's changed is the barrier: training a custom wake word is no longer a research project, it's a notebook you can open right now, and one entry in a wider collection of OVOS training notebooks for wake words, voices, and intents.
 
 ---
 


### PR DESCRIPTION
Companion post for WakeForge (the WW training suite) + ovos-ww-plugin-wakeforge. Code-validated: suite framing (11 featurizers x 15 heads x 15 losses), hardware tiers, wakeforge-quickstart CLI, voiceclonnx synthetic data, and the plugin's runtime config surface. Trained models load via ovos-ww-plugin-wakeforge (featurizer+head ONNX pair). No monetary values.