### PR TITLE
blog: OVOS Formal Specifications (the architecture repo / voice-OS ABI)

### DIFF
--- a/_posts/2026-12-02-ovos-formal-specifications.md
+++ b/_posts/2026-12-02-ovos-formal-specifications.md
@@ -12,15 +12,13 @@ ogImage:
 
 ## OVOS Is a Voice Operating System — and Now It Has a Written ABI
 
-Most "voice assistants" are products. You ask a question, they answer, and how they do it is a black box you're not meant to open. OpenVoiceOS is a different kind of thing, and the [**OVOS architecture repository**](https://github.com/OpenVoiceOS/architecture) is where we finally wrote down exactly *what* kind of thing.
+Most voice assistants are products: you ask a question, they answer, and how they do it stays a black box. OpenVoiceOS calls itself a **voice operating system**, not a voice assistant, and the [**OVOS architecture repository**](https://github.com/OpenVoiceOS/architecture) now writes down exactly what that means. It is the ABI of the platform: the documented contract that lets independent components — skills, satellites, orchestrators — talk to each other without knowing anything about each other's internals.
 
-Its own framing is the clearest: OVOS is a **voice operating system** — not a voice assistant. A voice assistant is a product that answers questions. A voice OS is a *platform*. It defines the boundary between what a user says and the computation that runs; it arbitrates which application handles each utterance; it manages conversation state across turns; and it provides a stable interface that third-party applications run against without knowing anything about each other. The architecture repo is the source of truth for that interface — the ABI of the voice OS.
+A voice OS defines the boundary between what a user says and the computation that runs. It arbitrates which application handles each utterance, manages conversation state across turns, and gives third-party applications a stable interface to run against. Until now, that interface lived only in code. The architecture repo makes it a document.
 
 ---
 
-## The operating-system analogy is not a metaphor
-
-The repository draws the comparison directly, and it holds up point for point:
+## Why it matters: the OS analogy holds point for point
 
 | Operating system | Voice OS equivalent |
 |---|---|
@@ -31,13 +29,13 @@ The repository draws the comparison directly, and it holds up point for point:
 | Loadable kernel modules | Pipeline and transformer plugins |
 | System-call ABI | The `match(utterances, lang, session) → Match` contract |
 
-The consequence is worth sitting with. Because there's a stable ABI, OVOS is a **runtime**, not a monolith: you can swap the scheduler (pipeline ordering), the NLU engines (pipeline plugins), the dialogue policy (converse and context), or the output layer (TTS, display) — in any combination — and everything else keeps working. A skill written against the intent stack runs on any conformant orchestrator, under any pipeline configuration, in any supported language. That is precisely the property an operating system gives you, and precisely the property most voice products don't.
+Because there is a stable ABI, OVOS is a runtime, not a monolith. You can swap the scheduler (pipeline ordering), the NLU engines (pipeline plugins), the dialogue policy (converse and context), or the output layer (TTS, display), in any combination, and everything else keeps working. A skill written against the intent stack runs on any conformant orchestrator, under any pipeline configuration, in any supported language.
 
 ---
 
-## What's actually specified
+## What shipped: 20 specifications
 
-The repository is **20 specifications**, grouped by the subsystem they govern. Each has a stable ID, a version, and normative text:
+The repository holds 20 specifications, grouped by the subsystem they govern. Each has a stable ID, a version, and normative text:
 
 - **The intent stack** — `INTENT-1` (sentence template grammar), `INTENT-2` (locale resource formats), `INTENT-3` (intent definition), `INTENT-4` (intent and entity registration). This is how a skill declares what it understands.
 - **Bus and session** — `MSG-1` (the bus message envelope), `SESSION-1` (the session carrier wire shape), `SESSION-2` (session lifecycle and state ownership), `BRIDGE-1` (bus bridging and opaque relay). This is how components talk and how state travels with a conversation.
@@ -45,27 +43,25 @@ The repository is **20 specifications**, grouped by the subsystem they govern. E
 - **Audio and display** — `AUDIO-IN-1` (audio input), `AUDIO-1` (audio output), `GUI-1` (the display subsystem).
 - **Media** — `OCP-1`, the OVOS Common Playback virtual media player.
 
-The point of splitting it this way is that a spec is a contract with a scope. You can implement `STOP-1` correctly without re-reading the whole platform, and someone auditing your stop behaviour knows exactly which document is the referee.
+Splitting the spec this way keeps each contract scoped. You can implement `STOP-1` correctly without reading the whole platform, and someone auditing your stop behaviour knows exactly which document is the referee.
 
----
+The specs are written in **RFC-2119 language** — the MUST / SHOULD / MAY vocabulary standards bodies use so "correct" is not a matter of opinion. When a spec says a component MUST emit an event, an implementation that skips it is not making a reasonable alternative choice. It is wrong, and the spec is the evidence.
 
-## RFC-2119, and what "Draft" means here
-
-The specs are written in **RFC-2119 language** — the MUST / SHOULD / MAY vocabulary that standards bodies use so that "correct" is not a matter of opinion. When a spec says a component MUST emit an event, an implementation that doesn't isn't making a reasonable alternative choice; it's wrong, and the spec is the evidence.
-
-Every spec in the repository is currently at **Draft** status, and the repo is careful about what that word means. A Draft spec here is still **prescriptive**: where an implementation diverges from it, the divergence is treated as an implementation bug, not a defect in the specification. Draft signals "we may still revise the text," not "this is optional." It's an honest label — the specs are young, they'll change — but they are already the authority, not a wish list.
+Every spec in the repository is currently at **Draft** status. Draft here still means **prescriptive**: where an implementation diverges from the text, that is treated as an implementation bug, not a defect in the spec. Draft signals "we may still revise the wording," not "this is optional."
 
 ---
 
 ## Not the same as the message models
 
-It's worth heading off a natural confusion. There is a separate OVOS effort, [ovos-pydantic-models](https://github.com/OpenVoiceOS/ovos-pydantic-models), that specifies what each bus *message looks like* — the exact fields of a `speak` or a `recognizer_loop:utterance` payload. These architecture specs are the other half: they specify how components *behave* — how the pipeline orders work, how a session propagates, how a stop cascades. Payload shape versus runtime behaviour. Two complementary bodies of work, deliberately kept apart, and together they're what let a second, independent implementation of OVOS be more than a hopeful guess.
+There is a separate OVOS effort, [ovos-pydantic-models](https://github.com/OpenVoiceOS/ovos-pydantic-models), that specifies what each bus message looks like — the exact fields of a `speak` or a `recognizer_loop:utterance` payload. The architecture specs cover the other half: how components behave — how the pipeline orders work, how a session propagates, how a stop cascades. Payload shape versus runtime behaviour, deliberately kept as two separate bodies of work.
 
-## Why write it down at all
+---
 
-An unwritten platform can't be reimplemented, can't be conformance-tested, and can't be trusted to stay stable as the code churns beneath it. Writing the ABI down changes all three. A satellite, a bridge, a from-scratch client, or a competing orchestrator now has a target to build against and a document to be judged by. Skill authors get guarantees they can rely on across releases. And OVOS itself gets the thing every mature platform eventually needs: a definition of "correct" that lives outside any one codebase, so the platform can outlast the particular lines of Python that implement it today.
+## How to use it
 
-That's the difference between a product and an operating system. One does what its vendor allows. The other publishes its contracts and invites you to build.
+Read the specs at [github.com/OpenVoiceOS/architecture](https://github.com/OpenVoiceOS/architecture). If you maintain a skill, check it against `INTENT-1` through `INTENT-4`. If you are building a satellite, a bridge, or a competing orchestrator, `MSG-1`, `SESSION-1`, and `PIPELINE-1` are the contracts to implement against. Where your implementation and the spec disagree, that is a bug report against your code, not a request to change the document.
+
+An unwritten platform cannot be reimplemented, cannot be conformance-tested, and cannot be trusted to stay stable as the code underneath it changes. Writing the ABI down fixes all three: skill authors get guarantees that hold across releases, and OVOS gets a definition of "correct" that lives outside any one codebase.
 
 ---
 

--- a/_posts/2026-12-02-ovos-formal-specifications.md
+++ b/_posts/2026-12-02-ovos-formal-specifications.md
@@ -1,5 +1,5 @@
 ---
-title: "OVOS Is a Voice Operating System — and Now It Has a Written ABI"
+title: "OVOS Is a Voice Operating System — and Now It Has a Written Protocol Spec"
 excerpt: "The OVOS architecture repository is a set of formal, implementation-agnostic specifications for how a voice OS's components talk to each other: 20 specs covering the intent stack, the bus and sessions, the pipeline, audio, GUI, and media. Written in RFC-2119 language, so 'correct' stops being a matter of opinion."
 coverImage: "/assets/blog/ngi/thumb.png"
 date: "2026-12-02T00:00:00.000Z"
@@ -10,26 +10,30 @@ ogImage:
   url: "/assets/blog/ngi/thumb.png"
 ---
 
-## OVOS Is a Voice Operating System — and Now It Has a Written ABI
+## OVOS Is a Voice Operating System — and Now It Has a Written Protocol Spec
 
-Most voice assistants are products: you ask a question, they answer, and how they do it stays a black box. OpenVoiceOS calls itself a **voice operating system**, not a voice assistant, and the [**OVOS architecture repository**](https://github.com/OpenVoiceOS/architecture) now writes down exactly what that means. It is the ABI of the platform: the documented contract that lets independent components — skills, satellites, orchestrators — talk to each other without knowing anything about each other's internals.
+Most voice assistants are products: you ask a question, they answer, and how they do it stays a black box. OpenVoiceOS calls itself a **voice operating system**, not a voice assistant, and the [**OVOS architecture repository**](https://github.com/OpenVoiceOS/architecture) now writes down exactly what that means. It is the wire contract of the platform: the documented rulebook that lets independent components — skills, satellite devices, orchestrators built by different people, on different hardware — talk to each other without knowing anything about each other's internals.
 
-A voice OS defines the boundary between what a user says and the computation that runs. It arbitrates which application handles each utterance, manages conversation state across turns, and gives third-party applications a stable interface to run against. Until now, that interface lived only in code. The architecture repo makes it a document.
+For someone using a voice assistant, this is what makes it possible to mix and match: run a skill written by one developer on a device built by another, swap the app that turns speech into an action, or move your setup to different hardware, and have the pieces keep working together. Until now, the rules for how those pieces cooperate lived only in code scattered across projects. The architecture repo makes it one document.
+
+*The rest of this post is for developers and maintainers building on OVOS — skill authors, satellite/bridge builders, and anyone writing an orchestrator.*
 
 ---
 
 ## Why it matters: the OS analogy holds point for point
 
-| Operating system | Voice OS equivalent |
-|---|---|
-| Process scheduler | Pipeline plugin ordering |
-| IPC / message passing | The bus and the MSG-1 envelope |
-| Shared memory | The session carrier |
-| Process supervision | The handler-lifecycle trio |
-| Loadable kernel modules | Pipeline and transformer plugins |
-| System-call ABI | The `match(utterances, lang, session) → Match` contract |
+This table maps the spec pieces to familiar operating-system concepts. It's an illustrative comparison, not an exact equivalence — treat it as a way in, not a spec in itself.
 
-Because there is a stable ABI, OVOS is a runtime, not a monolith. You can swap the scheduler (pipeline ordering), the NLU engines (pipeline plugins), the dialogue policy (converse and context), or the output layer (TTS, display), in any combination, and everything else keeps working. A skill written against the intent stack runs on any conformant orchestrator, under any pipeline configuration, in any supported language.
+| Operating system concept | Voice OS equivalent | In plain terms |
+|---|---|---|
+| Process scheduler | Pipeline plugin ordering | Decides which piece of software handles what you said, and in what order it's tried |
+| IPC / message passing | The bus and the MSG-1 envelope | The shared channel components use to send each other messages |
+| Shared memory | The session carrier | The bit of state that travels with a conversation so components stay in sync |
+| Process supervision | The handler-lifecycle trio | The rules for starting, tracking, and stopping a request as it's handled |
+| Loadable kernel modules | Pipeline and transformer plugins | Swappable building blocks — e.g. the natural-language understanding (NLU) engine that figures out intent, or the text-to-speech (TTS) engine that generates the reply |
+| System-call ABI | The `match()` contract every intent handler implements | The fixed shape every plugin must expose so the rest of the system can call it |
+
+Because there is a stable contract, OVOS is a runtime, not a monolith. You can swap the scheduler (pipeline ordering), the NLU engines (pipeline plugins), the dialogue policy (converse and context), or the output layer (TTS, display), in any combination, and everything else keeps working. A skill written against the intent stack runs on any conformant orchestrator, under any pipeline configuration, in any supported language.
 
 ---
 
@@ -57,11 +61,13 @@ There is a separate OVOS effort, [ovos-pydantic-models](https://github.com/OpenV
 
 ---
 
-## How to use it
+## How to try it
 
-Read the specs at [github.com/OpenVoiceOS/architecture](https://github.com/OpenVoiceOS/architecture). If you maintain a skill, check it against `INTENT-1` through `INTENT-4`. If you are building a satellite, a bridge, or a competing orchestrator, `MSG-1`, `SESSION-1`, and `PIPELINE-1` are the contracts to implement against. Where your implementation and the spec disagree, that is a bug report against your code, not a request to change the document.
+Read the specs at [github.com/OpenVoiceOS/architecture](https://github.com/OpenVoiceOS/architecture). If you maintain a skill, check it against `INTENT-1` through `INTENT-4`. If you are building a satellite, a bridge, or a competing orchestrator, `MSG-1`, `SESSION-1`, and `PIPELINE-1` are the contracts to implement against.
 
-An unwritten platform cannot be reimplemented, cannot be conformance-tested, and cannot be trusted to stay stable as the code underneath it changes. Writing the ABI down fixes all three: skill authors get guarantees that hold across releases, and OVOS gets a definition of "correct" that lives outside any one codebase.
+You don't have to implement the spec machinery from scratch: [**ovos-spec-tools**](https://github.com/OpenVoiceOS/ovos-spec-tools) is a reference implementation with the sentence-template expander, the locale resource loader, the dialog renderer, language matching, and the `ovos-spec-lint` linter. Depend on it instead of reimplementing that plumbing yourself. Where your implementation and the spec disagree, that is a bug report against your code, not a request to change the document.
+
+An unwritten platform cannot be reimplemented, cannot be checked for conformance, and cannot be trusted to stay stable as the code underneath it changes. Writing the spec down is the first step toward fixing all three. A conformance corpus and test harness are the planned next step, expected to live in `ovos-spec-tools`; they are not built yet. What's already true today: skill authors get a document that defines "correct" outside any one codebase, instead of having to read implementation source to guess at the contract.
 
 ---
 

--- a/_posts/2026-12-02-ovos-formal-specifications.md
+++ b/_posts/2026-12-02-ovos-formal-specifications.md
@@ -1,6 +1,6 @@
 ---
 title: "OVOS Is a Voice Operating System — and Now It Has a Written Protocol Spec"
-excerpt: "The OVOS architecture repository is a set of formal, implementation-agnostic specifications for how a voice OS's components talk to each other: 20 specs covering the intent stack, the bus and sessions, the pipeline, audio, GUI, and media. Written in RFC-2119 language, so 'correct' stops being a matter of opinion."
+excerpt: "The OVOS architecture repository is a set of formal, implementation-agnostic specifications for how a voice OS's components talk to each other: 20 specs covering the intent stack, the bus and sessions, the pipeline, audio, GUI, and media. Written in RFC-2119 language, so what counts as correct is written down instead of argued over."
 coverImage: "/assets/blog/ngi/thumb.png"
 date: "2026-12-02T00:00:00.000Z"
 author:
@@ -12,7 +12,7 @@ ogImage:
 
 ## OVOS Is a Voice Operating System — and Now It Has a Written Protocol Spec
 
-Most voice assistants are products: you ask a question, they answer, and how they do it stays a black box. OpenVoiceOS calls itself a **voice operating system**, not a voice assistant, and the [**OVOS architecture repository**](https://github.com/OpenVoiceOS/architecture) now writes down exactly what that means. It is the wire contract of the platform: the documented rulebook that lets independent components — skills, satellite devices, orchestrators built by different people, on different hardware — talk to each other without knowing anything about each other's internals.
+Most voice assistants are products: you ask a question, they answer, and how they do it stays a black box. OpenVoiceOS calls itself a **voice operating system**, not a voice assistant, and the [**OVOS architecture repository**](https://github.com/OpenVoiceOS/architecture) now writes down exactly what that means. It writes down the contract that lets independent components — skills, satellite devices, orchestrators built by different people, on different hardware — talk to each other without knowing anything about each other's internals.
 
 For someone using a voice assistant, this is what makes it possible to mix and match: run a skill written by one developer on a device built by another, swap the app that turns speech into an action, or move your setup to different hardware, and have the pieces keep working together. Until now, the rules for how those pieces cooperate lived only in code scattered across projects. The architecture repo makes it one document.
 
@@ -33,7 +33,7 @@ This table maps the spec pieces to familiar operating-system concepts. It's an i
 | Loadable kernel modules | Pipeline and transformer plugins | Swappable building blocks — e.g. the natural-language understanding (NLU) engine that figures out intent, or the text-to-speech (TTS) engine that generates the reply |
 | System-call ABI | The `match()` contract every intent handler implements | The fixed shape every plugin must expose so the rest of the system can call it |
 
-Because there is a stable contract, OVOS is a runtime, not a monolith. You can swap the scheduler (pipeline ordering), the NLU engines (pipeline plugins), the dialogue policy (converse and context), or the output layer (TTS, display), in any combination, and everything else keeps working. A skill written against the intent stack runs on any conformant orchestrator, under any pipeline configuration, in any supported language.
+Because there is a stable contract, OVOS is a runtime, not a monolith. You can swap the scheduler (pipeline ordering), the NLU engines (pipeline plugins), the dialogue policy (converse and context), or the output layer (TTS, display), in any combination, and everything else keeps working. A skill written against the intent stack is meant to run on any orchestrator that implements it, under any pipeline configuration, in any supported language — once conformance tooling exists to check an orchestrator against the spec.
 
 ---
 
@@ -49,7 +49,7 @@ The repository holds 20 specifications, grouped by the subsystem they govern. Ea
 
 Splitting the spec this way keeps each contract scoped. You can implement `STOP-1` correctly without reading the whole platform, and someone auditing your stop behaviour knows exactly which document is the referee.
 
-The specs are written in **RFC-2119 language** — the MUST / SHOULD / MAY vocabulary standards bodies use so "correct" is not a matter of opinion. When a spec says a component MUST emit an event, an implementation that skips it is not making a reasonable alternative choice. It is wrong, and the spec is the evidence.
+The specs are written in **RFC-2119 language** — the MUST / SHOULD / MAY vocabulary standards bodies use to make intent unambiguous. When a spec says a component MUST emit an event, an implementation that skips it is not making a reasonable alternative choice. It is wrong, and the spec is the evidence — even though nothing yet checks that automatically.
 
 Every spec in the repository is currently at **Draft** status. Draft here still means **prescriptive**: where an implementation diverges from the text, that is treated as an implementation bug, not a defect in the spec. Draft signals "we may still revise the wording," not "this is optional."
 
@@ -67,7 +67,7 @@ Read the specs at [github.com/OpenVoiceOS/architecture](https://github.com/OpenV
 
 You don't have to implement the spec machinery from scratch: [**ovos-spec-tools**](https://github.com/OpenVoiceOS/ovos-spec-tools) is a reference implementation with the sentence-template expander, the locale resource loader, the dialog renderer, language matching, and the `ovos-spec-lint` linter. Depend on it instead of reimplementing that plumbing yourself. Where your implementation and the spec disagree, that is a bug report against your code, not a request to change the document.
 
-An unwritten platform cannot be reimplemented, cannot be checked for conformance, and cannot be trusted to stay stable as the code underneath it changes. Writing the spec down is the first step toward fixing all three. A conformance corpus and test harness are the planned next step, expected to live in `ovos-spec-tools`; they are not built yet. What's already true today: skill authors get a document that defines "correct" outside any one codebase, instead of having to read implementation source to guess at the contract.
+An unwritten platform is harder to reimplement, harder to check, and harder to keep stable as the code underneath it changes. Writing the spec down is the first step. A conformance corpus and test harness are the planned next step, expected to live in `ovos-spec-tools`; they are not built yet. What's already true today: skill authors get a document that defines the intended behaviour outside any one codebase, instead of having to read implementation source to guess at the contract.
 
 ---
 
@@ -75,14 +75,4 @@ This work is part of the OpenVoiceOS **From Beta to Breakthrough** milestone, fu
 
 ---
 
-## Help Us Build Voice for Everyone
-
-OpenVoiceOS is more than software, it's a mission. If you believe voice assistants should be open, inclusive, and user-controlled, here's how you can help:
-
-- **💸 Donate**: Help us fund development, infrastructure, and legal protection.
-- **📣 Contribute Open Data**: Share voice samples and transcriptions under open licenses.
-- **🌍 Translate**: Help make OVOS accessible in every language.
-
-We're not building this for profit. We're building it for people. With your support, we can keep voice tech transparent, private, and community-owned.
-
-👉 [Support the project here](https://www.openvoiceos.org/contribution)
+Read the specs, file issues against `ovos-spec-tools`, or [support the project](https://www.openvoiceos.org/contribution).

--- a/_posts/2026-12-02-ovos-formal-specifications.md
+++ b/_posts/2026-12-02-ovos-formal-specifications.md
@@ -1,0 +1,86 @@
+---
+title: "OVOS Is a Voice Operating System — and Now It Has a Written ABI"
+excerpt: "The OVOS architecture repository is a set of formal, implementation-agnostic specifications for how a voice OS's components talk to each other: 23 specs covering the intent stack, the bus and sessions, the pipeline, audio, GUI, and media. Written in RFC-2119 language, so 'correct' stops being a matter of opinion."
+coverImage: "/assets/blog/ngi/thumb.png"
+date: "2026-12-02T00:00:00.000Z"
+author:
+  name: JarbasAl
+  picture: "https://avatars.githubusercontent.com/u/33701864"
+ogImage:
+  url: "/assets/blog/ngi/thumb.png"
+---
+
+## OVOS Is a Voice Operating System — and Now It Has a Written ABI
+
+Most "voice assistants" are products. You ask a question, they answer, and how they do it is a black box you're not meant to open. OpenVoiceOS is a different kind of thing, and the [**OVOS architecture repository**](https://github.com/OpenVoiceOS/architecture) is where we finally wrote down exactly *what* kind of thing.
+
+Its own framing is the clearest: OVOS is a **voice operating system** — not a voice assistant. A voice assistant is a product that answers questions. A voice OS is a *platform*. It defines the boundary between what a user says and the computation that runs; it arbitrates which application handles each utterance; it manages conversation state across turns; and it provides a stable interface that third-party applications run against without knowing anything about each other. The architecture repo is the source of truth for that interface — the ABI of the voice OS.
+
+---
+
+## The operating-system analogy is not a metaphor
+
+The repository draws the comparison directly, and it holds up point for point:
+
+| Operating system | Voice OS equivalent |
+|---|---|
+| Process scheduler | Pipeline plugin ordering |
+| IPC / message passing | The bus and the MSG-1 envelope |
+| Shared memory | The session carrier |
+| Process supervision | The handler-lifecycle trio |
+| Loadable kernel modules | Pipeline and transformer plugins |
+| System-call ABI | The `match(utterances, lang, session) → Match` contract |
+
+The consequence is worth sitting with. Because there's a stable ABI, OVOS is a **runtime**, not a monolith: you can swap the scheduler (pipeline ordering), the NLU engines (pipeline plugins), the dialogue policy (converse and context), or the output layer (TTS, display) — in any combination — and everything else keeps working. A skill written against the intent stack runs on any conformant orchestrator, under any pipeline configuration, in any supported language. That is precisely the property an operating system gives you, and precisely the property most voice products don't.
+
+---
+
+## What's actually specified
+
+The repository is **23 specifications**, grouped by the subsystem they govern. Each has a stable ID, a version, and normative text:
+
+- **The intent stack** — `INTENT-1` (sentence template grammar), `INTENT-2` (locale resource formats), `INTENT-3` (intent definition), `INTENT-4` (intent and entity registration). This is how a skill declares what it understands.
+- **Bus and session** — `MSG-1` (the bus message envelope), `SESSION-1` (the session carrier wire shape), `SESSION-2` (session lifecycle and state ownership), `BRIDGE-1` (bus bridging and opaque relay), `USER-ID-1` (user identity resolution). This is how components talk and how state travels with a conversation.
+- **The pipeline** — `PIPELINE-1` (the utterance lifecycle), plus the plugins that live in it: `TRANSFORM-1`, `CONTEXT-1`, `CONVERSE-1`, `STOP-1`, `PERSONA-1`, `FALLBACK-1`, `COMMON-QUERY-1`. This is how an utterance becomes an action.
+- **Audio and display** — `AUDIO-IN-1` (audio input), `AUDIO-1` (audio output), `GUI-1` (the display subsystem).
+- **Media** — `OCP-1`, the OVOS Common Playback virtual media player.
+
+The point of splitting it this way is that a spec is a contract with a scope. You can implement `STOP-1` correctly without re-reading the whole platform, and someone auditing your stop behaviour knows exactly which document is the referee.
+
+---
+
+## RFC-2119, and what "Draft" means here
+
+The specs are written in **RFC-2119 language** — the MUST / SHOULD / MAY vocabulary that standards bodies use so that "correct" is not a matter of opinion. When a spec says a component MUST emit an event, an implementation that doesn't isn't making a reasonable alternative choice; it's wrong, and the spec is the evidence.
+
+Every spec in the repository is currently at **Draft** status, and the repo is careful about what that word means. A Draft spec here is still **prescriptive**: where an implementation diverges from it, the divergence is treated as an implementation bug, not a defect in the specification. Draft signals "we may still revise the text," not "this is optional." It's an honest label — the specs are young, they'll change — but they are already the authority, not a wish list.
+
+---
+
+## Not the same as the message models
+
+It's worth heading off a natural confusion. There is a separate OVOS effort, [ovos-pydantic-models](https://github.com/OpenVoiceOS/ovos-pydantic-models), that specifies what each bus *message looks like* — the exact fields of a `speak` or a `recognizer_loop:utterance` payload. These architecture specs are the other half: they specify how components *behave* — how the pipeline orders work, how a session propagates, how a stop cascades. Payload shape versus runtime behaviour. Two complementary bodies of work, deliberately kept apart, and together they're what let a second, independent implementation of OVOS be more than a hopeful guess.
+
+## Why write it down at all
+
+An unwritten platform can't be reimplemented, can't be conformance-tested, and can't be trusted to stay stable as the code churns beneath it. Writing the ABI down changes all three. A satellite, a bridge, a from-scratch client, or a competing orchestrator now has a target to build against and a document to be judged by. Skill authors get guarantees they can rely on across releases. And OVOS itself gets the thing every mature platform eventually needs: a definition of "correct" that lives outside any one codebase, so the platform can outlast the particular lines of Python that implement it today.
+
+That's the difference between a product and an operating system. One does what its vendor allows. The other publishes its contracts and invites you to build.
+
+---
+
+This work is part of the OpenVoiceOS **From Beta to Breakthrough** milestone, funded through the [NGI0 Commons Fund](https://nlnet.nl/commonsfund), a fund established by [NLnet](https://nlnet.nl) with financial support from the European Commission's [Next Generation Internet](https://ngi.eu) programme, under the aegis of [DG Communications Networks, Content and Technology](https://commission.europa.eu/about-european-commission/departments-and-executive-agencies/communications-networks-content-and-technology_en) under grant agreement No [101135429](https://cordis.europa.eu/project/id/101135429). Additional funding is made available by the [Swiss State Secretariat for Education, Research and Innovation](https://www.sbfi.admin.ch/sbfi/en/home.html) (SERI).
+
+---
+
+## Help Us Build Voice for Everyone
+
+OpenVoiceOS is more than software, it's a mission. If you believe voice assistants should be open, inclusive, and user-controlled, here's how you can help:
+
+- **💸 Donate**: Help us fund development, infrastructure, and legal protection.
+- **📣 Contribute Open Data**: Share voice samples and transcriptions under open licenses.
+- **🌍 Translate**: Help make OVOS accessible in every language.
+
+We're not building this for profit. We're building it for people. With your support, we can keep voice tech transparent, private, and community-owned.
+
+👉 [Support the project here](https://www.openvoiceos.org/contribution)

--- a/_posts/2026-12-02-ovos-formal-specifications.md
+++ b/_posts/2026-12-02-ovos-formal-specifications.md
@@ -1,6 +1,6 @@
 ---
 title: "OVOS Is a Voice Operating System — and Now It Has a Written ABI"
-excerpt: "The OVOS architecture repository is a set of formal, implementation-agnostic specifications for how a voice OS's components talk to each other: 23 specs covering the intent stack, the bus and sessions, the pipeline, audio, GUI, and media. Written in RFC-2119 language, so 'correct' stops being a matter of opinion."
+excerpt: "The OVOS architecture repository is a set of formal, implementation-agnostic specifications for how a voice OS's components talk to each other: 20 specs covering the intent stack, the bus and sessions, the pipeline, audio, GUI, and media. Written in RFC-2119 language, so 'correct' stops being a matter of opinion."
 coverImage: "/assets/blog/ngi/thumb.png"
 date: "2026-12-02T00:00:00.000Z"
 author:
@@ -37,10 +37,10 @@ The consequence is worth sitting with. Because there's a stable ABI, OVOS is a *
 
 ## What's actually specified
 
-The repository is **23 specifications**, grouped by the subsystem they govern. Each has a stable ID, a version, and normative text:
+The repository is **20 specifications**, grouped by the subsystem they govern. Each has a stable ID, a version, and normative text:
 
 - **The intent stack** — `INTENT-1` (sentence template grammar), `INTENT-2` (locale resource formats), `INTENT-3` (intent definition), `INTENT-4` (intent and entity registration). This is how a skill declares what it understands.
-- **Bus and session** — `MSG-1` (the bus message envelope), `SESSION-1` (the session carrier wire shape), `SESSION-2` (session lifecycle and state ownership), `BRIDGE-1` (bus bridging and opaque relay), `USER-ID-1` (user identity resolution). This is how components talk and how state travels with a conversation.
+- **Bus and session** — `MSG-1` (the bus message envelope), `SESSION-1` (the session carrier wire shape), `SESSION-2` (session lifecycle and state ownership), `BRIDGE-1` (bus bridging and opaque relay). This is how components talk and how state travels with a conversation.
 - **The pipeline** — `PIPELINE-1` (the utterance lifecycle), plus the plugins that live in it: `TRANSFORM-1`, `CONTEXT-1`, `CONVERSE-1`, `STOP-1`, `PERSONA-1`, `FALLBACK-1`, `COMMON-QUERY-1`. This is how an utterance becomes an action.
 - **Audio and display** — `AUDIO-IN-1` (audio input), `AUDIO-1` (audio output), `GUI-1` (the display subsystem).
 - **Media** — `OCP-1`, the OVOS Common Playback virtual media player.


### PR DESCRIPTION
Companion post (DRAFT) for the **architecture** repo — OVOS Formal Specifications, the behavioural ABI of the voice OS. Validated against the repo: the voice-OS framing + OS-analogy table, the 23 Draft specs grouped (intent stack, bus/session, pipeline, audio/GUI, media), RFC-2119 language, and the 'Draft = prescriptive' semantics. **Explicitly distinct from #85** (ovos-pydantic-models = message payload shapes; this = component behaviour). No monetary values. Held draft pending review. Scheduled 2026-12-02.